### PR TITLE
Variadics for runtime type enforcement on ordered collections

### DIFF
--- a/src/Protocol/Version1.php
+++ b/src/Protocol/Version1.php
@@ -97,7 +97,7 @@ class Version1 implements ProtocolInterface
         $rsa = self::getRsa();
         $rsa->loadKey($key->raw());
         $signature = $rsa->sign(
-            Util::preAuthEncode([$header, $data, $footer])
+            Util::preAuthEncode(...[$header, $data, $footer])
         );
         if ($footer) {
             return $header .
@@ -134,7 +134,7 @@ class Version1 implements ProtocolInterface
         $rsa = self::getRsa();
         $rsa->loadKey($key->raw());
         $valid = $rsa->verify(
-            Util::preAuthEncode([$givenHeader, $message, $footer]),
+            Util::preAuthEncode(...[$givenHeader, $message, $footer]),
             $signature
         );
         if (!$valid) {
@@ -185,7 +185,7 @@ class Version1 implements ProtocolInterface
         }
         $mac = \hash_hmac(
             self::HASH_ALGO,
-            Util::preAuthEncode([$header, $nonce, $ciphertext, $footer]),
+            Util::preAuthEncode(...[$header, $nonce, $ciphertext, $footer]),
             $authKey,
             true
         );
@@ -237,7 +237,7 @@ class Version1 implements ProtocolInterface
 
         $calc = \hash_hmac(
             self::HASH_ALGO,
-            Util::preAuthEncode([$header, $nonce, $ciphertext, $footer]),
+            Util::preAuthEncode(...[$header, $nonce, $ciphertext, $footer]),
             $authKey,
             true
         );

--- a/src/Protocol/Version2.php
+++ b/src/Protocol/Version2.php
@@ -91,7 +91,7 @@ class Version2 implements ProtocolInterface
     ): string {
         $header = self::HEADER . '.public.';
         $signature = \sodium_crypto_sign_detached(
-            Util::preAuthEncode([$header, $data, $footer]),
+            Util::preAuthEncode(...[$header, $data, $footer]),
             $key->raw()
         );
         if ($footer) {
@@ -140,7 +140,7 @@ class Version2 implements ProtocolInterface
 
         $valid = \sodium_crypto_sign_verify_detached(
             $signature,
-            Util::preAuthEncode([$givenHeader, $message, $footer]),
+            Util::preAuthEncode(...[$givenHeader, $message, $footer]),
             $key->raw()
         );
         if (!$valid) {
@@ -184,7 +184,7 @@ class Version2 implements ProtocolInterface
         );
         $ciphertext = \ParagonIE_Sodium_Compat::crypto_aead_xchacha20poly1305_ietf_encrypt(
             $plaintext,
-            Util::preAuthEncode([$header, $nonce, $footer]),
+            Util::preAuthEncode(...[$header, $nonce, $footer]),
             $nonce,
             $key->raw()
         );
@@ -234,7 +234,7 @@ class Version2 implements ProtocolInterface
         );
         return \ParagonIE_Sodium_Compat::crypto_aead_xchacha20poly1305_ietf_decrypt(
             $ciphertext,
-            Util::preAuthEncode([$header, $nonce, $footer]),
+            Util::preAuthEncode(...[$header, $nonce, $footer]),
             $nonce,
             $key->raw()
         );

--- a/src/Util.php
+++ b/src/Util.php
@@ -112,10 +112,10 @@ class Util
      * followed by each message. This provides a more explicit domain
      * separation between each piece of the message.
      *
-     * @param array<int, string> $pieces
+     * @param string ...$pieces
      * @return string
      */
-    public static function preAuthEncode(array $pieces): string
+    public static function preAuthEncode(string ...$pieces): string
     {
         $accumulator = \pack('P', \count($pieces));
         foreach ($pieces as $piece) {

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -76,32 +76,32 @@ class UtilTest extends TestCase
     {
         $this->assertSame(
             '0000000000000000',
-            Hex::encode(Util::preAuthEncode([])),
+            Hex::encode(Util::preAuthEncode(...[])),
             'Empty array'
         );
         $this->assertSame(
             '01000000000000000000000000000000',
-            Hex::encode(Util::preAuthEncode([''])),
+            Hex::encode(Util::preAuthEncode(...[''])),
             'Array of empty string'
         );
         $this->assertSame(
             '020000000000000000000000000000000000000000000000',
-            Hex::encode(Util::preAuthEncode(['', ''])),
+            Hex::encode(Util::preAuthEncode(...['', ''])),
             'Array of empty strings'
         );
         $this->assertSame(
             '0100000000000000070000000000000050617261676f6e',
-            Hex::encode(Util::preAuthEncode(['Paragon'])),
+            Hex::encode(Util::preAuthEncode(...['Paragon'])),
             'Array of non-empty string'
         );
         $this->assertSame(
             '0200000000000000070000000000000050617261676f6e0a00000000000000496e6974696174697665',
-            Hex::encode(Util::preAuthEncode(['Paragon', 'Initiative'])),
+            Hex::encode(Util::preAuthEncode(...['Paragon', 'Initiative'])),
             'Array of two non-empty strings'
         );
         $this->assertSame(
             '0100000000000000190000000000000050617261676f6e0a00000000000000496e6974696174697665',
-            Hex::encode(Util::preAuthEncode([
+            Hex::encode(Util::preAuthEncode(...[
                 'Paragon' . chr(10) . str_repeat("\0", 7) . 'Initiative'
             ])),
             'Ensure that faked padding results in different prefixes'


### PR DESCRIPTION
Swap an instance of `@param array<int, string> $pieces` for `@param string ...$pieces`. This lets PHP do some type checking at runtime for ordered collections.

This also serves to explicitly state that any intended ordering must be based on the array's internal ordering (and not on, say, the numerical order of the array keys – which may differ if they were manually set out of order for example).

I could only find one instance where this seemed to be an appropriate change, there may be more I've missed though.

It is possible to be preferable to reject this change in favour of maybe being able to keep the API the same when proper generics hopefully land in PHP. Though as mentioned, there is a subtly that variadics address, which is making it explicit where the ordering of a collection is obtained from – a proper generic PHP `array<int, string>` would likely suffer from the numerical key order and array internal order being able to disagree (as normal PHP `array` does today). Furthermore, when PHP has proper generics it will be possible to implement type-safe ordered lists, so `array<int, string>` will probably no longer be the best choice anyway 🤷‍♂️ 