### PR TITLE
Allowed protocols as a type

### DIFF
--- a/src/JsonToken.php
+++ b/src/JsonToken.php
@@ -380,10 +380,10 @@ class JsonToken
                                 \get_class($key)
                         );
                     }
-                    if (!\hash_equals($this->version, $key->getProtocol())) {
+                    if (!\hash_equals($this->version, $key->getProtocol()::header())) {
                         throw new InvalidKeyException(
                             'Invalid key type. This key is for ' .
-                                $key->getProtocol() .
+                                $key->getProtocol()::header() .
                                 ', not ' .
                                 $this->version
                         );
@@ -684,7 +684,7 @@ class JsonToken
     public function withKey(KeyInterface $key, bool $checkPurpose = false): self
     {
         $cloned = clone $this;
-        
+
         if ($checkPurpose) {
             switch ($cloned->purpose) {
                 case 'local':
@@ -706,10 +706,10 @@ class JsonToken
                                 \get_class($key)
                         );
                     }
-                    if (!\hash_equals($cloned->version, $key->getProtocol())) {
+                    if (!\hash_equals($cloned->version, $key->getProtocol()::header())) {
                         throw new InvalidKeyException(
                             'Invalid key type. This key is for ' .
-                                $key->getProtocol() .
+                                $key->getProtocol()::header() .
                                 ', not ' .
                                 $cloned->version
                         );

--- a/src/KeyInterface.php
+++ b/src/KeyInterface.php
@@ -12,9 +12,9 @@ interface KeyInterface
      * The intended version for this protocol. Currently only meaningful
      * in asymmetric cryptography.
      *
-     * @return string
+     * @return ProtocolInterface
      */
-    public function getProtocol(): string;
+    public function getProtocol(): ProtocolInterface;
 
     /**
      * @return string

--- a/src/Keys/AsymmetricPublicKey.php
+++ b/src/Keys/AsymmetricPublicKey.php
@@ -4,7 +4,10 @@ namespace ParagonIE\Paseto\Keys;
 
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use ParagonIE\ConstantTime\Binary;
-use ParagonIE\Paseto\KeyInterface;
+use ParagonIE\Paseto\{
+    KeyInterface,
+    ProtocolInterface
+};
 use ParagonIE\Paseto\Protocol\Version2;
 
 /**
@@ -16,20 +19,22 @@ class AsymmetricPublicKey implements KeyInterface
     /** @var string $key */
     protected $key = '';
 
-    /** @var string $protocol */
-    protected $protocol = Version2::HEADER;
+    /** @var ProtocolInterface $protocol */
+    protected $protocol;
 
     /**
      * AsymmetricPublicKey constructor.
      * @param string $keyMaterial
-     * @param string $protocol
+     * @param ProtocolInterface $protocol
      * @throws \Exception
      */
     public function __construct(
         string $keyMaterial,
-        string $protocol = Version2::HEADER
+        ProtocolInterface $protocol = null
     ) {
-        if (\hash_equals($protocol, Version2::HEADER)) {
+        $protocol = $protocol ?? new Version2;
+
+        if (\hash_equals($protocol::header(), Version2::HEADER)) {
             $len = Binary::safeStrlen($keyMaterial);
             if ($len !== SODIUM_CRYPTO_SIGN_PUBLICKEYBYTES) {
                 throw new \Exception(
@@ -60,9 +65,9 @@ class AsymmetricPublicKey implements KeyInterface
     }
 
     /**
-     * @return string
+     * @return ProtocolInterface
      */
-    public function getProtocol(): string
+    public function getProtocol(): ProtocolInterface
     {
         return $this->protocol;
     }

--- a/src/Keys/SymmetricKey.php
+++ b/src/Keys/SymmetricKey.php
@@ -5,6 +5,7 @@ namespace ParagonIE\Paseto\Keys;
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use ParagonIE\Paseto\{
     KeyInterface,
+    ProtocolInterface,
     Protocol\Version2,
     Util
 };
@@ -21,21 +22,21 @@ class SymmetricKey implements KeyInterface
     /** @var string $key */
     protected $key = '';
 
-    /** @var string $protocol */
-    protected $protocol = Version2::HEADER;
+    /** @var ProtocolInterface $protocol */
+    protected $protocol;
 
     /**
      * SymmetricKey constructor.
      *
      * @param string $keyMaterial
-     * @param string $protocol
+     * @param ProtocolInterface|null $protocol
      */
     public function __construct(
         string $keyMaterial,
-        string $protocol = Version2::HEADER
+        ProtocolInterface $protocol = null
     ) {
         $this->key = $keyMaterial;
-        $this->protocol = $protocol;
+        $this->protocol = $protocol ?? new Version2;
     }
 
     /**
@@ -59,9 +60,9 @@ class SymmetricKey implements KeyInterface
     }
 
     /**
-     * @return string
+     * @return ProtocolInterface
      */
-    public function getProtocol(): string
+    public function getProtocol(): ProtocolInterface
     {
         return $this->protocol;
     }

--- a/src/Protocol/Version1.php
+++ b/src/Protocol/Version1.php
@@ -35,6 +35,16 @@ class Version1 implements ProtocolInterface
     protected static $rsa;
 
     /**
+     * A unique header string with which the protocol can be identified.
+     *
+     * @return string
+     */
+    public static function header(): string
+    {
+        return self::HEADER;
+    }
+
+    /**
      * Encrypt a message using a shared key.
      *
      * @param string $data

--- a/src/Protocol/Version1.php
+++ b/src/Protocol/Version1.php
@@ -35,6 +35,12 @@ class Version1 implements ProtocolInterface
     protected static $rsa;
 
     /**
+     * Must be constructable with no arguments so an instance may be passed
+     * around in a type safe way.
+     */
+    public function __construct() {}
+
+    /**
      * A unique header string with which the protocol can be identified.
      *
      * @return string

--- a/src/Protocol/Version2.php
+++ b/src/Protocol/Version2.php
@@ -26,6 +26,16 @@ class Version2 implements ProtocolInterface
     const HEADER = 'v2';
 
     /**
+     * A unique header string with which the protocol can be identified.
+     *
+     * @return string
+     */
+    public static function header(): string
+    {
+        return self::HEADER;
+    }
+
+    /**
      * Encrypt a message using a shared key.
      *
      * @param string $data

--- a/src/Protocol/Version2.php
+++ b/src/Protocol/Version2.php
@@ -26,6 +26,12 @@ class Version2 implements ProtocolInterface
     const HEADER = 'v2';
 
     /**
+     * Must be constructable with no arguments so an instance may be passed
+     * around in a type safe way.
+     */
+    public function __construct() {}
+
+    /**
      * A unique header string with which the protocol can be identified.
      *
      * @return string

--- a/src/ProtocolCollection.php
+++ b/src/ProtocolCollection.php
@@ -24,7 +24,7 @@ final class ProtocolCollection
     private $protocols;
 
     /** @var array<string, ProtocolInterface> */
-    static $headerLookup = [];
+    private static $headerLookup = [];
 
     /**
      * @param ProtocolInterface ...$protocols

--- a/src/ProtocolCollection.php
+++ b/src/ProtocolCollection.php
@@ -1,0 +1,105 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\Paseto;
+
+use ParagonIE\Paseto\Protocol\{
+    Version1,
+    Version2
+};
+
+use ParagonIE\Paseto\Exception\InvalidVersionException;
+
+final class ProtocolCollection
+{
+    // Our built-in whitelist of protocol types is defined here.
+    /**
+     * @const array<int, string>
+     */
+    const WHITELIST = [
+        Version1::class,
+        Version2::class,
+    ];
+
+    /** @var array<int, ProtocolInterface> */
+    private $protocols;
+
+    /** @var array<string, ProtocolInterface> */
+    static $headerLookup = [];
+
+    /**
+     * @param ProtocolInterface ...$protocols
+     * @throws \LogicException
+     * @throws InvalidVersionException
+     */
+    public function __construct(ProtocolInterface ...$protocols)
+    {
+        if (empty($protocols)) {
+            throw new \LogicException('At least one version is necessary');
+        }
+
+        /** @var ProtocolInterface $protocol */
+        foreach ($protocols as $protocol) {
+            if (!self::isValid($protocol)) {
+                throw new InvalidVersionException('Disallowed or unsupported version');
+            }
+        }
+
+        $this->protocols = $protocols;
+    }
+
+    /**
+     * Does the collection contain the given protocol
+     */
+    public function has(ProtocolInterface $protocol): bool
+    {
+        return \in_array($protocol, $this->protocols);
+    }
+
+    /**
+     * Is the given protocol supported?
+     *
+     * @param ProtocolInterface $protocol
+     * @return bool
+     */
+    public static function isValid(ProtocolInterface $protocol): bool
+    {
+        return \in_array(\get_class($protocol), self::WHITELIST, true);
+    }
+
+    /**
+     * @param string $header
+     * @return ProtocolInterface
+     * @throws InvalidVersionException
+     */
+    public static function protocolFromHeader(string $header): ProtocolInterface {
+        if (empty(self::$headerLookup)) {
+            /** @var string $protocolClass */
+            foreach (self::WHITELIST as $protocolClass) {
+                self::$headerLookup[$protocolClass::header()] = new $protocolClass;
+            }
+        }
+
+        if (!\array_key_exists($header, self::$headerLookup)) {
+            throw new InvalidVersionException('Disallowed or unsupported version');
+        }
+
+        return self::$headerLookup[$header];
+    }
+
+    /**
+     * Get a collection of all supported protocols
+     *
+     * @return self
+     */
+    public static function default(): self
+    {
+        return new self(...\array_map(
+            function (string $p): ProtocolInterface {
+                /** @var ProtocolInterface */
+                $protocol = new $p;
+                return $protocol;
+            },
+            self::WHITELIST
+        ));
+    }
+}

--- a/src/ProtocolCollection.php
+++ b/src/ProtocolCollection.php
@@ -49,6 +49,8 @@ final class ProtocolCollection
 
     /**
      * Does the collection contain the given protocol
+     *
+     * @return bool
      */
     public function has(ProtocolInterface $protocol): bool
     {

--- a/src/ProtocolInterface.php
+++ b/src/ProtocolInterface.php
@@ -15,6 +15,12 @@ use ParagonIE\Paseto\Keys\{
 interface ProtocolInterface
 {
     /**
+     * Must be constructable with no arguments so an instance may be passed
+     * around in a type safe way.
+     */
+    public function __construct();
+
+    /**
      * A unique header string with which the protocol can be identified.
      *
      * @return string

--- a/src/ProtocolInterface.php
+++ b/src/ProtocolInterface.php
@@ -15,6 +15,13 @@ use ParagonIE\Paseto\Keys\{
 interface ProtocolInterface
 {
     /**
+     * A unique header string with which the protocol can be identified.
+     *
+     * @return string
+     */
+    public static function header(): string;
+
+    /**
      * Encrypt a message using a shared key.
      *
      * @param string $data

--- a/tests/Version1Test.php
+++ b/tests/Version1Test.php
@@ -78,8 +78,8 @@ class Version1Test extends TestCase
     {
         $rsa = Version1::getRsa();
         $keypair = $rsa->createKey(2048);
-        $privateKey = new AsymmetricSecretKey($keypair['privatekey'], 'v1');
-        $publicKey = new AsymmetricPublicKey($keypair['publickey'], 'v1');
+        $privateKey = new AsymmetricSecretKey($keypair['privatekey'], new Version1);
+        $publicKey = new AsymmetricPublicKey($keypair['publickey'], new Version1);
 
         $year = (int) (\date('Y')) + 1;
         $messages = [

--- a/tests/Version2VectorTest.php
+++ b/tests/Version2VectorTest.php
@@ -55,14 +55,14 @@ class Version2VectorTest extends TestCase
                 'b4cbfb43df4ce210727d953e4a713307fa19bb7d9f85041438d9e11b942a3774' .
                 '1eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415d0e20b1a2'
             ),
-            Version2::HEADER
+            new Version2
         );
 
         $this->publicKey = new AsymmetricPublicKey(
             Hex::decode(
                 '1eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415d0e20b1a2'
             ),
-            Version2::HEADER
+            new Version2
         );
     }
 


### PR DESCRIPTION
Instead of maintaining a whitelist of allowed protocol implementations in a switch/case buried in a method, the whitelist is now in `ParagonIE\Paseto\ProtocolCollection::WHITELIST`.

Also make protocol version validation implicit in the construction of a `ProtocolCollection`, so that invalid nonsense protocol header strings just fail to construct a `ProtocolInterface` (instead of trying to validate the string values everywhere they are used).