### PR TITLE
Type safety on the 'purpose' and KeyInterface intent disambiguation

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -327,10 +327,10 @@ class Builder
                         \get_class($key)
                 );
             }
-            switch ($this->purpose->rawString()) {
-                case 'local':
+            switch ($this->purpose) {
+                case Purpose::local():
                     break;
-                case 'public':
+                case Purpose::public():
                     if (!($key->getProtocol() instanceof $this->version)) {
                         throw new InvalidKeyException(
                             'Invalid key type. This key is for ' .
@@ -430,8 +430,8 @@ class Builder
         $claims = \json_encode($this->token->getClaims());
         $protocol = $this->version;
         ProtocolCollection::throwIfUnsupported($protocol);
-        switch ($this->purpose->rawString()) {
-            case 'local':
+        switch ($this->purpose) {
+            case Purpose::local():
                 if ($this->key instanceof SymmetricKey) {
                     $this->cached = (string) $protocol::encrypt(
                         $claims,
@@ -442,7 +442,7 @@ class Builder
                     return $this->cached;
                 }
                 break;
-            case 'public':
+            case Purpose::public():
                 if ($this->key instanceof AsymmetricSecretKey) {
                     try {
                         $this->cached = (string) $protocol::sign(

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -421,7 +421,7 @@ class Builder
             throw new InvalidKeyException('Key cannot be null');
         }
         if (\is_null($this->purpose)) {
-            throw new InvalidKeyException('Purpose cannot be null');
+            throw new InvalidPurposeException('Purpose cannot be null');
         }
         // Mutual sanity checks
         $this->setKey($this->key, true);

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -116,7 +116,7 @@ class Builder
         $instance = new static($baseToken);
         $instance->key = $key;
         $instance->version = $version;
-        $instance->purpose = new Purpose('local');
+        $instance->purpose = Purpose::local();
         return $instance;
     }
 
@@ -139,7 +139,7 @@ class Builder
         $instance = new static($baseToken);
         $instance->key = $key;
         $instance->version = $version;
-        $instance->purpose = new Purpose('public');
+        $instance->purpose = Purpose::public();
         return $instance;
     }
 
@@ -352,7 +352,7 @@ class Builder
 
     /**
      * Set the purpose for this token. Allowed values:
-     * new Purpose('local'), new Purpose('public').
+     * Purpose::local(), Purpose::public().
      *
      * @param Purpose $purpose
      * @param bool $checkKeyType
@@ -604,7 +604,7 @@ class Builder
     /**
      * Return a new JsonToken instance with a new purpose.
      * Allowed values:
-     * new Purpose('local'), new Purpose('public').
+     * Purpose::local(), Purpose::public().
      *
      * @param Purpose $purpose
      * @param bool $checkKeyType

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -37,7 +37,7 @@ class Builder
     /** @var string $explicitNonce -- Do not use this. It's for unit testing! */
     protected $explicitNonce = '';
 
-    /** @var KeyInterface|null $key */
+    /** @var SendingKey|null $key */
     protected $key = null;
 
     /** @var Purpose|null $purpose */
@@ -54,14 +54,14 @@ class Builder
      *
      * @param JsonToken|null $baseToken
      * @param ProtocolInterface|null $protocol
-     * @param KeyInterface|null $key
+     * @param SendingKey|null $key
      *
      * @throws PasetoException
      */
     public function __construct(
         JsonToken $baseToken = null,
         ProtocolInterface $protocol = null,
-        KeyInterface $key = null
+        SendingKey $key = null
     ) {
         if (!$baseToken) {
             $baseToken = new JsonToken();
@@ -309,12 +309,12 @@ class Builder
      * Set the cryptographic key used to authenticate (and possibly encrypt)
      * the serialized token.
      *
-     * @param KeyInterface $key
+     * @param SendingKey $key
      * @param bool $checkPurpose
      * @return self
      * @throws PasetoException
      */
-    public function setKey(KeyInterface $key, bool $checkPurpose = false): self
+    public function setKey(SendingKey $key, bool $checkPurpose = false): self
     {
         if ($checkPurpose) {
             if (!isset($this->purpose)) {
@@ -591,12 +591,12 @@ class Builder
      * Return a new JsonToken instance, with the provided cryptographic key used
      * to authenticate (and possibly encrypt) the serialized token.
      *
-     * @param KeyInterface $key
+     * @param SendingKey $key
      * @param bool $checkPurpose
      * @return self
      * @throws PasetoException
      */
-    public function withKey(KeyInterface $key, bool $checkPurpose = false): self
+    public function withKey(SendingKey $key, bool $checkPurpose = false): self
     {
         return (clone $this)->setKey($key, $checkPurpose);
     }

--- a/src/Keys/AsymmetricPublicKey.php
+++ b/src/Keys/AsymmetricPublicKey.php
@@ -5,7 +5,7 @@ namespace ParagonIE\Paseto\Keys;
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use ParagonIE\ConstantTime\Binary;
 use ParagonIE\Paseto\{
-    KeyInterface,
+    ReceivingKey,
     ProtocolInterface
 };
 use ParagonIE\Paseto\Protocol\Version2;
@@ -14,7 +14,7 @@ use ParagonIE\Paseto\Protocol\Version2;
  * Class AsymmetricPublicKey
  * @package ParagonIE\Paseto\Keys
  */
-class AsymmetricPublicKey implements KeyInterface
+class AsymmetricPublicKey implements ReceivingKey
 {
     /** @var string $key */
     protected $key = '';

--- a/src/Keys/AsymmetricSecretKey.php
+++ b/src/Keys/AsymmetricSecretKey.php
@@ -5,7 +5,7 @@ namespace ParagonIE\Paseto\Keys;
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use ParagonIE\ConstantTime\Binary;
 use ParagonIE\Paseto\{
-    KeyInterface,
+    SendingKey,
     ProtocolInterface
 };
 use ParagonIE\Paseto\Protocol\{
@@ -17,7 +17,7 @@ use ParagonIE\Paseto\Protocol\{
  * Class AsymmetricSecretKey
  * @package ParagonIE\Paseto\Keys
  */
-class AsymmetricSecretKey implements KeyInterface
+class AsymmetricSecretKey implements SendingKey
 {
     /** @var string $key */
     protected $key;

--- a/src/Keys/SymmetricKey.php
+++ b/src/Keys/SymmetricKey.php
@@ -4,7 +4,8 @@ namespace ParagonIE\Paseto\Keys;
 
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use ParagonIE\Paseto\{
-    KeyInterface,
+    ReceivingKey,
+    SendingKey,
     ProtocolInterface,
     Protocol\Version2,
     Util
@@ -14,7 +15,7 @@ use ParagonIE\Paseto\{
  * Class SymmetricKey
  * @package ParagonIE\Paseto\Keys
  */
-class SymmetricKey implements KeyInterface
+class SymmetricKey implements ReceivingKey, SendingKey
 {
     const INFO_ENCRYPTION = 'paseto-encryption-key';
     const INFO_AUTHENTICATION = 'paseto-auth-key-for-aead';

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -163,8 +163,8 @@ class Parser
         }
 
         // Let's verify/decode according to the appropriate method:
-        switch ($purpose->rawString()) {
-            case 'local':
+        switch ($purpose) {
+            case Purpose::local():
                 $footer = (\count($pieces) > 3)
                     ? Base64UrlSafe::decode($pieces[3])
                     : '';
@@ -176,7 +176,7 @@ class Parser
                     throw new PasetoException('An error occurred', 0, $ex);
                 }
                 break;
-            case 'public':
+            case Purpose::public():
                 $footer = (\count($pieces) > 4)
                     ? Base64UrlSafe::decode($pieces[4])
                     : '';

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -31,7 +31,7 @@ class Parser
     /** @var ProtocolCollection */
     protected $allowedVersions;
 
-    /** @var KeyInterface $key */
+    /** @var ReceivingKey $key */
     protected $key;
 
     /** @var Purpose|null $purpose */
@@ -45,14 +45,14 @@ class Parser
      *
      * @param ProtocolCollection|null $allowedVersions
      * @param Purpose|null $purpose
-     * @param KeyInterface|null $key
+     * @param ReceivingKey|null $key
      * @param array<int, ValidationRuleInterface> $parserRules
      * @throws PasetoException
      */
     public function __construct(
         ProtocolCollection $allowedVersions = null,
         Purpose $purpose = null,
-        KeyInterface $key = null,
+        ReceivingKey $key = null,
         array $parserRules = []
     ) {
         $this->allowedVersions = $allowedVersions ?? ProtocolCollection::default();
@@ -226,12 +226,12 @@ class Parser
     /**
      * Specify the key for the token we are going to parse.
      *
-     * @param KeyInterface $key
+     * @param ReceivingKey $key
      * @param bool $checkPurpose
      * @return self
      * @throws PasetoException
      */
-    public function setKey(KeyInterface $key, bool $checkPurpose = false): self
+    public function setKey(ReceivingKey $key, bool $checkPurpose = false): self
     {
         if ($checkPurpose) {
             if (!isset($this->purpose)) {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -83,7 +83,7 @@ class Parser
         /** @var Parser $instance */
         $instance = new static(
             $allowedVersions ?? ProtocolCollection::default(),
-            new Purpose('local'),
+            Purpose::local(),
             $key
         );
         return $instance;
@@ -103,7 +103,7 @@ class Parser
         /** @var Parser $instance */
         $instance = new static(
             $allowedVersions ?? ProtocolCollection::default(),
-            new Purpose('public'),
+            Purpose::public(),
             $key
         );
         return $instance;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -34,7 +34,7 @@ class Parser
     /** @var KeyInterface $key */
     protected $key;
 
-    /** @var string $purpose */
+    /** @var Purpose|null $purpose */
     protected $purpose;
 
     /** @var array<int, ValidationRuleInterface> */
@@ -44,14 +44,14 @@ class Parser
      * Parser constructor.
      *
      * @param ProtocolCollection|null $allowedVersions
-     * @param string $purpose
+     * @param Purpose|null $purpose
      * @param KeyInterface|null $key
      * @param array<int, ValidationRuleInterface> $parserRules
      * @throws PasetoException
      */
     public function __construct(
         ProtocolCollection $allowedVersions = null,
-        string $purpose = '',
+        Purpose $purpose = null,
         KeyInterface $key = null,
         array $parserRules = []
     ) {
@@ -83,7 +83,7 @@ class Parser
         /** @var Parser $instance */
         $instance = new static(
             $allowedVersions ?? ProtocolCollection::default(),
-            'local',
+            new Purpose('local'),
             $key
         );
         return $instance;
@@ -103,7 +103,7 @@ class Parser
         /** @var Parser $instance */
         $instance = new static(
             $allowedVersions ?? ProtocolCollection::default(),
-            'public',
+            new Purpose('public'),
             $key
         );
         return $instance;
@@ -147,42 +147,42 @@ class Parser
             throw new InvalidVersionException('Disallowed or unsupported version');
         }
 
-        /** @var string $purpose */
+        /** @var Purpose $purpose */
         $footer = '';
-        $purpose = $pieces[1];
+        $purpose = new Purpose($pieces[1]);
 
         // $this->purpose is not mandatory, but if it's set, verify against it.
-        if (!empty($this->purpose)) {
-            if (!\hash_equals($this->purpose, $purpose)) {
+        if (isset($this->purpose)) {
+            if (!$this->purpose->equals($purpose)) {
                 throw new InvalidPurposeException('Disallowed or unsupported purpose');
             }
         }
 
+        if (!$purpose->isReceivingKeyValid($this->key)) {
+            throw new InvalidKeyException('Invalid key type');
+        }
+
         // Let's verify/decode according to the appropriate method:
-        switch ($purpose) {
+        switch ($purpose->rawString()) {
             case 'local':
-                if (!($this->key instanceof SymmetricKey)) {
-                    throw new InvalidKeyException('Invalid key type');
-                }
                 $footer = (\count($pieces) > 3)
                     ? Base64UrlSafe::decode($pieces[3])
                     : '';
                 try {
                     /** @var string $decoded */
+                    /** @var SymmetricKey $this->key */
                     $decoded = $protocol::decrypt($tainted, $this->key, $footer);
                 } catch (\Throwable $ex) {
                     throw new PasetoException('An error occurred', 0, $ex);
                 }
                 break;
             case 'public':
-                if (!($this->key instanceof AsymmetricPublicKey)) {
-                    throw new InvalidKeyException('Invalid key type');
-                }
                 $footer = (\count($pieces) > 4)
                     ? Base64UrlSafe::decode($pieces[4])
                     : '';
                 try {
                     /** @var string $decoded */
+                    /** @var AsymmetricPublicKey $this->key */
                     $decoded = $protocol::verify($tainted, $this->key, $footer);
                 } catch (\Throwable $ex) {
                     throw new PasetoException('An error occurred', 0, $ex);
@@ -234,29 +234,15 @@ class Parser
     public function setKey(KeyInterface $key, bool $checkPurpose = false): self
     {
         if ($checkPurpose) {
-            switch ($this->purpose) {
-                case 'local':
-                    if (!($key instanceof SymmetricKey)) {
-                        throw new InvalidKeyException(
-                            'Invalid key type. Expected ' .
-                                SymmetricKey::class .
-                                ', got ' .
-                                \get_class($key)
-                        );
-                    }
-                    break;
-                case 'public':
-                    if (!($key instanceof AsymmetricPublicKey)) {
-                        throw new InvalidKeyException(
-                            'Invalid key type. Expected ' .
-                                AsymmetricPublicKey::class .
-                                ', got ' .
-                                \get_class($key)
-                        );
-                    }
-                    break;
-                default:
-                    throw new InvalidKeyException('Unknown purpose');
+            if (!isset($this->purpose)) {
+                throw new InvalidKeyException('Unknown purpose');
+            } elseif (!$this->purpose->isReceivingKeyValid($key)) {
+                throw new InvalidKeyException(
+                    'Invalid key type. Expected ' .
+                        $this->purpose->expectedReceivingKeyType() .
+                        ', got ' .
+                        \get_class($key)
+                );
             }
         }
         $this->key = $key;
@@ -266,32 +252,21 @@ class Parser
     /**
      * Specify the allowed 'purpose' for the token we are going to parse.
      *
-     * @param string $purpose
+     * @param Purpose $purpose
      * @param bool $checkKeyType
      * @return self
      * @throws PasetoException
      */
-    public function setPurpose(string $purpose, bool $checkKeyType = false): self
+    public function setPurpose(Purpose $purpose, bool $checkKeyType = false): self
     {
         if ($checkKeyType) {
-            $keyType = \get_class($this->key);
-            switch ($keyType) {
-                case SymmetricKey::class:
-                    if (!\hash_equals('local', $purpose)) {
-                        throw new InvalidPurposeException(
-                            'Invalid purpose. Expected local, got ' . $purpose
-                        );
-                    }
-                    break;
-                case AsymmetricPublicKey::class:
-                    if (!\hash_equals('public', $purpose)) {
-                        throw new InvalidPurposeException(
-                            'Invalid purpose. Expected public, got ' . $purpose
-                        );
-                    }
-                    break;
-                default:
-                    throw new InvalidPurposeException('Unknown purpose: ' . $purpose);
+            /** @var Purpose */
+            $expectedPurpose = Purpose::fromReceivingKey($this->key);
+            if (!$purpose->equals($expectedPurpose)) {
+                throw new InvalidPurposeException(
+                    'Invalid purpose. Expected '.$expectedPurpose->rawString()
+                    .', got ' . $purpose->rawString()
+                );
             }
         }
 

--- a/src/Purpose.php
+++ b/src/Purpose.php
@@ -57,6 +57,16 @@ final class Purpose
         $this->fuzz = \random_bytes(16);
     }
 
+    public static function local(): self
+    {
+        return new self('local');
+    }
+
+    public static function public(): self
+    {
+        return new self('public');
+    }
+
     public function equals(self $purpose): bool
     {
         return \hash_equals($purpose->purpose, $this->purpose);

--- a/src/Purpose.php
+++ b/src/Purpose.php
@@ -1,0 +1,126 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\Paseto;
+
+use ParagonIE\Paseto\Keys\{
+    AsymmetricSecretKey,
+    AsymmetricPublicKey,
+    SymmetricKey
+};
+use ParagonIE\Paseto\Exception\InvalidPurposeException;
+
+final class Purpose
+{
+    const WHITELIST = [
+        'local',
+        'public',
+    ];
+
+    const EXPECTED_SENDING_KEYS = [
+        'local'  => SymmetricKey::class,
+        'public' => AsymmetricSecretKey::class,
+    ];
+
+    const EXPECTED_RECEIVING_KEYS = [
+        'local'  => SymmetricKey::class,
+        'public' => AsymmetricPublicKey::class,
+    ];
+
+    /** @var array<string, string> */
+    private static $sendingKeyToPurpose;
+
+    /** @var array<string, string> */
+    private static $receivingKeyToPurpose;
+
+    /**
+     * @var string
+     */
+    private $fuzz;
+
+    /**
+     * @var string
+     */
+    private $purpose;
+
+    /**
+     * @throws InvalidPurposeException
+     */
+    public function __construct(string $rawString)
+    {
+        if (!self::isValid($rawString)) {
+            throw new InvalidPurposeException('Unknown purpose: ' . $rawString);
+        }
+
+        $this->purpose = $rawString;
+        // prevent use of the == operator
+        // i.e. new Purpose('a') == new Purpose('a') will now be false
+        $this->fuzz = \random_bytes(16);
+    }
+
+    public function equals(self $purpose): bool
+    {
+        return \hash_equals($purpose->purpose, $this->purpose);
+    }
+
+    public function isSendingKeyValid(KeyInterface $key): bool
+    {
+        $expectedKeyType = $this->expectedSendingKeyType();
+        return $key instanceof $expectedKeyType;
+    }
+
+    public function isReceivingKeyValid(KeyInterface $key): bool
+    {
+        $expectedKeyType = $this->expectedReceivingKeyType();
+        return $key instanceof $expectedKeyType;
+    }
+
+    public function expectedSendingKeyType(): string
+    {
+        /** @var string */
+        $keyType = self::EXPECTED_SENDING_KEYS[$this->rawString()];
+
+        return $keyType;
+    }
+
+    public function expectedReceivingKeyType(): string
+    {
+        /** @var string */
+        $keyType = self::EXPECTED_RECEIVING_KEYS[$this->rawString()];
+
+        return $keyType;
+    }
+
+    public function rawString(): string
+    {
+        return $this->purpose;
+    }
+
+    public function __clone()
+    {
+        // reconstruct to change the fuzz value
+        $this->__construct($this->rawString());
+    }
+
+    public static function isValid(string $rawString): bool
+    {
+        return \in_array($rawString, self::WHITELIST, true);
+    }
+
+    public static function fromSendingKey(KeyInterface $key): self
+    {
+        if (empty(self::$sendingKeyToPurpose)) {
+            self::$sendingKeyToPurpose = \array_flip(self::EXPECTED_SENDING_KEYS);
+        }
+
+        return new self(self::$sendingKeyToPurpose[\get_class($key)]);
+    }
+
+    public static function fromReceivingKey(KeyInterface $key): self
+    {
+        if (empty(self::$receivingKeyToPurpose)) {
+            self::$receivingKeyToPurpose = \array_flip(self::EXPECTED_RECEIVING_KEYS);
+        }
+
+        return new self(self::$receivingKeyToPurpose[\get_class($key)]);
+    }
+}

--- a/src/Purpose.php
+++ b/src/Purpose.php
@@ -72,13 +72,13 @@ final class Purpose
         return \hash_equals($purpose->purpose, $this->purpose);
     }
 
-    public function isSendingKeyValid(KeyInterface $key): bool
+    public function isSendingKeyValid(SendingKey $key): bool
     {
         $expectedKeyType = $this->expectedSendingKeyType();
         return $key instanceof $expectedKeyType;
     }
 
-    public function isReceivingKeyValid(KeyInterface $key): bool
+    public function isReceivingKeyValid(ReceivingKey $key): bool
     {
         $expectedKeyType = $this->expectedReceivingKeyType();
         return $key instanceof $expectedKeyType;
@@ -116,19 +116,23 @@ final class Purpose
         return \in_array($rawString, self::WHITELIST, true);
     }
 
-    public static function fromSendingKey(KeyInterface $key): self
+    public static function fromSendingKey(SendingKey $key): self
     {
         if (empty(self::$sendingKeyToPurpose)) {
-            self::$sendingKeyToPurpose = \array_flip(self::EXPECTED_SENDING_KEYS);
+            /** @var array<string, string> */
+            $expectedSendingKeys = self::EXPECTED_SENDING_KEYS;
+            self::$sendingKeyToPurpose = \array_flip($expectedSendingKeys);
         }
 
         return new self(self::$sendingKeyToPurpose[\get_class($key)]);
     }
 
-    public static function fromReceivingKey(KeyInterface $key): self
+    public static function fromReceivingKey(ReceivingKey $key): self
     {
         if (empty(self::$receivingKeyToPurpose)) {
-            self::$receivingKeyToPurpose = \array_flip(self::EXPECTED_RECEIVING_KEYS);
+            /** @var array<string, string> */
+            $expectedReceivingKeys = self::EXPECTED_RECEIVING_KEYS;
+            self::$receivingKeyToPurpose = \array_flip($expectedReceivingKeys);
         }
 
         return new self(self::$receivingKeyToPurpose[\get_class($key)]);

--- a/src/Purpose.php
+++ b/src/Purpose.php
@@ -9,27 +9,51 @@ use ParagonIE\Paseto\Keys\{
 };
 use ParagonIE\Paseto\Exception\InvalidPurposeException;
 
+/**
+ * Class Purpose
+ * @package ParagonIE\Paseto
+ */
 final class Purpose
 {
+    /**
+     * A whitelist of allowed values/modes. This simulates an enum.
+     * @const array<int, string>
+     */
     const WHITELIST = [
         'local',
         'public',
     ];
 
+    /**
+     * When sending, which type of key is expected for each mode.
+     * @const array<string, string>
+     */
     const EXPECTED_SENDING_KEYS = [
         'local'  => SymmetricKey::class,
         'public' => AsymmetricSecretKey::class,
     ];
 
+    /**
+     * When receiving, which type of key is expected for each mode.
+     * @const array<string, string>
+     */
     const EXPECTED_RECEIVING_KEYS = [
         'local'  => SymmetricKey::class,
         'public' => AsymmetricPublicKey::class,
     ];
 
-    /** @var array<string, string> */
+    /**
+     * Inverse of EXPECTED_SENDING_KEYS, evaluated and statically cached at
+     * runtime.
+     * @var array<string, string>
+     */
     private static $sendingKeyToPurpose;
 
-    /** @var array<string, string> */
+    /**
+     * Inverse of EXPECTED_RECEIVING_KEYS, evaluated and statically cached at
+     * runtime.
+     * @var array<string, string>
+     */
     private static $receivingKeyToPurpose;
 
     /**
@@ -38,6 +62,9 @@ final class Purpose
     private $purpose;
 
     /**
+     * Allowed values in self::WHITELIST
+     *
+     * @param string $rawString
      * @throws InvalidPurposeException
      */
     public function __construct(string $rawString)
@@ -49,33 +76,69 @@ final class Purpose
         $this->purpose = $rawString;
     }
 
+    /**
+     * Create a local purpose.
+     *
+     * @return self
+     */
     public static function local(): self
     {
         return new self('local');
     }
 
+    /**
+     * Create a public purpose.
+     *
+     * @return self
+     */
     public static function public(): self
     {
         return new self('public');
     }
 
+    /**
+     * Compare the instance with $purpose in constant time.
+     *
+     * @param self $Purpose
+     * @return bool
+     */
     public function equals(self $purpose): bool
     {
         return \hash_equals($purpose->purpose, $this->purpose);
     }
 
+    /**
+     * Does the given $key correspond to the expected SendingKey for the
+     * instance's mode?
+     *
+     * @param SendingKey $key
+     * @return bool
+     */
     public function isSendingKeyValid(SendingKey $key): bool
     {
         $expectedKeyType = $this->expectedSendingKeyType();
         return $key instanceof $expectedKeyType;
     }
 
+    /**
+     * Does the given $key correspond to the expected ReceivingKey for the
+     * instance's mode?
+     *
+     * @param ReceivingKey $key
+     * @return bool
+     */
     public function isReceivingKeyValid(ReceivingKey $key): bool
     {
         $expectedKeyType = $this->expectedReceivingKeyType();
         return $key instanceof $expectedKeyType;
     }
 
+    /**
+     * Retrieve the class name as a string which corresponds to the expected
+     * SendingKey for the instance's mode.
+     *
+     * @return string
+     */
     public function expectedSendingKeyType(): string
     {
         /** @var string */
@@ -84,6 +147,12 @@ final class Purpose
         return $keyType;
     }
 
+    /**
+     * Retrieve the class name as a string which corresponds to the expected
+     * ReceivingKey for the instance's mode.
+     *
+     * @return string
+     */
     public function expectedReceivingKeyType(): string
     {
         /** @var string */
@@ -92,16 +161,34 @@ final class Purpose
         return $keyType;
     }
 
+    /**
+     * Retrieve the underlying raw string value for the instance's mode.
+     *
+     * @return string
+     */
     public function rawString(): string
     {
         return $this->purpose;
     }
 
+    /**
+     * Determine whether new Purpose($rawString) will succeed prior to calling
+     * it.
+     *
+     * @param string $rawString
+     * @return bool
+     */
     public static function isValid(string $rawString): bool
     {
         return \in_array($rawString, self::WHITELIST, true);
     }
 
+    /**
+     * Given a SendingKey, retrieve the corresponding Purpose.
+     *
+     * @param SendingKey $key
+     * @return self
+     */
     public static function fromSendingKey(SendingKey $key): self
     {
         if (empty(self::$sendingKeyToPurpose)) {
@@ -113,6 +200,12 @@ final class Purpose
         return new self(self::$sendingKeyToPurpose[\get_class($key)]);
     }
 
+    /**
+     * Given a ReceivingKey, retrieve the corresponding Purpose.
+     *
+     * @param ReceivingKey $key
+     * @return self
+     */
     public static function fromReceivingKey(ReceivingKey $key): self
     {
         if (empty(self::$receivingKeyToPurpose)) {

--- a/src/Purpose.php
+++ b/src/Purpose.php
@@ -97,6 +97,40 @@ final class Purpose
     }
 
     /**
+     * Given a SendingKey, retrieve the corresponding Purpose.
+     *
+     * @param SendingKey $key
+     * @return self
+     */
+    public static function fromSendingKey(SendingKey $key): self
+    {
+        if (empty(self::$sendingKeyToPurpose)) {
+            /** @var array<string, string> */
+            $expectedSendingKeys = self::EXPECTED_SENDING_KEYS;
+            self::$sendingKeyToPurpose = \array_flip($expectedSendingKeys);
+        }
+
+        return new self(self::$sendingKeyToPurpose[\get_class($key)]);
+    }
+
+    /**
+     * Given a ReceivingKey, retrieve the corresponding Purpose.
+     *
+     * @param ReceivingKey $key
+     * @return self
+     */
+    public static function fromReceivingKey(ReceivingKey $key): self
+    {
+        if (empty(self::$receivingKeyToPurpose)) {
+            /** @var array<string, string> */
+            $expectedReceivingKeys = self::EXPECTED_RECEIVING_KEYS;
+            self::$receivingKeyToPurpose = \array_flip($expectedReceivingKeys);
+        }
+
+        return new self(self::$receivingKeyToPurpose[\get_class($key)]);
+    }
+
+    /**
      * Compare the instance with $purpose in constant time.
      *
      * @param self $Purpose
@@ -105,6 +139,18 @@ final class Purpose
     public function equals(self $purpose): bool
     {
         return \hash_equals($purpose->purpose, $this->purpose);
+    }
+
+    /**
+     * Determine whether new Purpose($rawString) will succeed prior to calling
+     * it.
+     *
+     * @param string $rawString
+     * @return bool
+     */
+    public static function isValid(string $rawString): bool
+    {
+        return \in_array($rawString, self::WHITELIST, true);
     }
 
     /**
@@ -169,51 +215,5 @@ final class Purpose
     public function rawString(): string
     {
         return $this->purpose;
-    }
-
-    /**
-     * Determine whether new Purpose($rawString) will succeed prior to calling
-     * it.
-     *
-     * @param string $rawString
-     * @return bool
-     */
-    public static function isValid(string $rawString): bool
-    {
-        return \in_array($rawString, self::WHITELIST, true);
-    }
-
-    /**
-     * Given a SendingKey, retrieve the corresponding Purpose.
-     *
-     * @param SendingKey $key
-     * @return self
-     */
-    public static function fromSendingKey(SendingKey $key): self
-    {
-        if (empty(self::$sendingKeyToPurpose)) {
-            /** @var array<string, string> */
-            $expectedSendingKeys = self::EXPECTED_SENDING_KEYS;
-            self::$sendingKeyToPurpose = \array_flip($expectedSendingKeys);
-        }
-
-        return new self(self::$sendingKeyToPurpose[\get_class($key)]);
-    }
-
-    /**
-     * Given a ReceivingKey, retrieve the corresponding Purpose.
-     *
-     * @param ReceivingKey $key
-     * @return self
-     */
-    public static function fromReceivingKey(ReceivingKey $key): self
-    {
-        if (empty(self::$receivingKeyToPurpose)) {
-            /** @var array<string, string> */
-            $expectedReceivingKeys = self::EXPECTED_RECEIVING_KEYS;
-            self::$receivingKeyToPurpose = \array_flip($expectedReceivingKeys);
-        }
-
-        return new self(self::$receivingKeyToPurpose[\get_class($key)]);
     }
 }

--- a/src/Purpose.php
+++ b/src/Purpose.php
@@ -35,11 +35,6 @@ final class Purpose
     /**
      * @var string
      */
-    private $fuzz;
-
-    /**
-     * @var string
-     */
     private $purpose;
 
     /**
@@ -52,9 +47,6 @@ final class Purpose
         }
 
         $this->purpose = $rawString;
-        // prevent use of the == operator
-        // i.e. new Purpose('a') == new Purpose('a') will now be false
-        $this->fuzz = \random_bytes(16);
     }
 
     public static function local(): self
@@ -103,12 +95,6 @@ final class Purpose
     public function rawString(): string
     {
         return $this->purpose;
-    }
-
-    public function __clone()
-    {
-        // reconstruct to change the fuzz value
-        $this->__construct($this->rawString());
     }
 
     public static function isValid(string $rawString): bool

--- a/src/ReceivingKey.php
+++ b/src/ReceivingKey.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\Paseto;
+
+/**
+ * Interface ReceivingKey
+ * @package ParagonIE\Paseto
+ */
+interface ReceivingKey extends KeyInterface
+{}

--- a/src/SendingKey.php
+++ b/src/SendingKey.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\Paseto;
+
+/**
+ * Interface SendingKey
+ * @package ParagonIE\Paseto
+ */
+interface SendingKey extends KeyInterface
+{}

--- a/tests/JsonTokenTest.php
+++ b/tests/JsonTokenTest.php
@@ -33,7 +33,7 @@ class JsonTokenTest extends TestCase
         // $nonce = crypto_generichash('Paragon Initiative Enterprises, LLC', '', 24);
         $nonce = Hex::decode('45742c976d684ff84ebdc0de59809a97cda2f64c84fda19b');
         $builder = (new Builder())
-            ->setPurpose(new Purpose('local'))
+            ->setPurpose(Purpose::local())
             ->setExplicitNonce($nonce)
             ->setKey($key)
             ->set('data', 'this is a signed message')
@@ -57,7 +57,7 @@ class JsonTokenTest extends TestCase
         );
 
         // Now let's switch gears to asymmetric crypto:
-        $builder->setPurpose(new Purpose('public'))
+        $builder->setPurpose(Purpose::public())
                 ->setKey(new AsymmetricSecretKey('YELLOW SUBMARINE, BLACK WIZARDRY'), true);
         $this->assertSame(
             'v2.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9BAOu3lUQMVHnBcPSkuORw51yiGGQ3QFUMoJO9U0gRAdAOPQEZFsd0YM_GZuBcmrXEOD1Re-Ila8vfPrfM5S6Ag',
@@ -88,7 +88,7 @@ class JsonTokenTest extends TestCase
         $footerArray = ['key-id' => 'gandalf0'];
 
         $token = (new Builder())
-            ->setPurpose(new Purpose('local'))
+            ->setPurpose(Purpose::local())
             ->setExplicitNonce($nonce)
             ->setKey($key)
             ->set('data', 'this is a signed message')
@@ -142,7 +142,7 @@ class JsonTokenTest extends TestCase
         $nonce = Hex::decode('45742c976d684ff84ebdc0de59809a97cda2f64c84fda19b');
         $footerArray = ['key-id' => 'gandalf0'];
         $builder = (new Builder())
-            ->setPurpose(new Purpose('local'))
+            ->setPurpose(Purpose::local())
             ->setExplicitNonce($nonce)
             ->setKey($key)
             ->set('data', 'this is a signed message')

--- a/tests/JsonTokenTest.php
+++ b/tests/JsonTokenTest.php
@@ -5,6 +5,7 @@ namespace ParagonIE\Paseto\Tests;
 use ParagonIE\ConstantTime\Hex;
 use ParagonIE\Paseto\Builder;
 use ParagonIE\Paseto\JsonToken;
+use ParagonIE\Paseto\Purpose;
 use ParagonIE\Paseto\Exception\PasetoException;
 use ParagonIE\Paseto\Keys\{
     AsymmetricSecretKey,
@@ -32,7 +33,7 @@ class JsonTokenTest extends TestCase
         // $nonce = crypto_generichash('Paragon Initiative Enterprises, LLC', '', 24);
         $nonce = Hex::decode('45742c976d684ff84ebdc0de59809a97cda2f64c84fda19b');
         $builder = (new Builder())
-            ->setPurpose('local')
+            ->setPurpose(new Purpose('local'))
             ->setExplicitNonce($nonce)
             ->setKey($key)
             ->set('data', 'this is a signed message')
@@ -56,7 +57,7 @@ class JsonTokenTest extends TestCase
         );
 
         // Now let's switch gears to asymmetric crypto:
-        $builder->setPurpose('public')
+        $builder->setPurpose(new Purpose('public'))
                 ->setKey(new AsymmetricSecretKey('YELLOW SUBMARINE, BLACK WIZARDRY'), true);
         $this->assertSame(
             'v2.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9BAOu3lUQMVHnBcPSkuORw51yiGGQ3QFUMoJO9U0gRAdAOPQEZFsd0YM_GZuBcmrXEOD1Re-Ila8vfPrfM5S6Ag',
@@ -87,7 +88,7 @@ class JsonTokenTest extends TestCase
         $footerArray = ['key-id' => 'gandalf0'];
 
         $token = (new Builder())
-            ->setPurpose('local')
+            ->setPurpose(new Purpose('local'))
             ->setExplicitNonce($nonce)
             ->setKey($key)
             ->set('data', 'this is a signed message')
@@ -141,7 +142,7 @@ class JsonTokenTest extends TestCase
         $nonce = Hex::decode('45742c976d684ff84ebdc0de59809a97cda2f64c84fda19b');
         $footerArray = ['key-id' => 'gandalf0'];
         $builder = (new Builder())
-            ->setPurpose('local')
+            ->setPurpose(new Purpose('local'))
             ->setExplicitNonce($nonce)
             ->setKey($key)
             ->set('data', 'this is a signed message')

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -11,6 +11,7 @@ use ParagonIE\Paseto\Keys\{
     SymmetricKey
 };
 use ParagonIE\Paseto\Parser;
+use ParagonIE\Paseto\Purpose;
 use ParagonIE\Paseto\Protocol\Version2;
 use ParagonIE\Paseto\ProtocolCollection;
 use ParagonIE\Paseto\Rules\NotExpired;
@@ -37,7 +38,7 @@ class ParserTest extends TestCase
 
         $serialized = 'v2.local.3fNxan9FHjedQRSONRnT7Ce_KhhpB0NrlHwAGsCb54x0FhrjBfeNN4uPHFiO5H0iPCZSjwfEkkfiGeYpE6KAfr1Zm3G-VTe4lcXtgDyKATYULT-zLPfshRqisk4n7EbGufWuqilYvYXMCiYbaA';
         $parser = (new Parser())
-            ->setPurpose('local')
+            ->setPurpose(new Purpose('local'))
             ->setKey($key);
         $token = $parser->parse($serialized);
         $builder = (Builder::getLocal($key, new Version2(), $token))
@@ -70,7 +71,7 @@ class ParserTest extends TestCase
         $parser->parse($serialized);
 
         // Switch to asymmetric-key crypto:
-        $builder->setPurpose('public')
+        $builder->setPurpose(new Purpose('public'))
             ->setExplicitNonce($nonce)
             ->setKey(new AsymmetricSecretKey('YELLOW SUBMARINE, BLACK WIZARDRY'), true);
         $this->assertSame(

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -38,7 +38,7 @@ class ParserTest extends TestCase
 
         $serialized = 'v2.local.3fNxan9FHjedQRSONRnT7Ce_KhhpB0NrlHwAGsCb54x0FhrjBfeNN4uPHFiO5H0iPCZSjwfEkkfiGeYpE6KAfr1Zm3G-VTe4lcXtgDyKATYULT-zLPfshRqisk4n7EbGufWuqilYvYXMCiYbaA';
         $parser = (new Parser())
-            ->setPurpose(new Purpose('local'))
+            ->setPurpose(Purpose::local())
             ->setKey($key);
         $token = $parser->parse($serialized);
         $builder = (Builder::getLocal($key, new Version2(), $token))
@@ -71,7 +71,7 @@ class ParserTest extends TestCase
         $parser->parse($serialized);
 
         // Switch to asymmetric-key crypto:
-        $builder->setPurpose(new Purpose('public'))
+        $builder->setPurpose(Purpose::public())
             ->setExplicitNonce($nonce)
             ->setKey(new AsymmetricSecretKey('YELLOW SUBMARINE, BLACK WIZARDRY'), true);
         $this->assertSame(

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -90,7 +90,7 @@ class ParserTest extends TestCase
     {
         $secretKey = new AsymmetricSecretKey('YELLOW SUBMARINE, BLACK WIZARDRY');
         $publicKey = $secretKey->getPublicKey();
-        $parser = new Parser(ProtocolCollection::default(), 'public', $publicKey);
+        $parser = new Parser(ProtocolCollection::default(), Purpose::public(), $publicKey);
         $tainted = 'v2.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9BAOu3lUQMVHnBcPSkuORw51yiGGQ3QFUMoJO9U0gRAdAOPQEZFsd0YM_GZuBcmrXEOD1Re-Ila8vfPrfM5S6Ag';
 
         $token = $parser->parse($tainted);


### PR DESCRIPTION
This is based on my other PR to avoid conflicts since some of the same code is changed.

I found #36 while doing this refactoring, but this does nothing to address it (hence WIP). It merely replicates the previous behaviour.

I've also removed what I think was some redundant code in the `JsonToken::withKey` etc... (to avoid refactoring to an identical implementation twice).

Things can be improved in this PR, this just to test the waters on the general idea.
