### PR TITLE
Usability/fix docs and convenience

### DIFF
--- a/docs/02-PHP-Library/README.md
+++ b/docs/02-PHP-Library/README.md
@@ -83,7 +83,7 @@ use ParagonIE\Paseto\ProtocolCollection;
  * @var string $providedToken
  * @var SymmetricKey $sharedKey
  */
-$parser = Parser::getLocal($sharedKey, [Version2::HEADER]);
+$parser = Parser::getLocal($sharedKey, ProtocolCollection::v2());
 // This is the same as:
 $parser = (new Parser())
     ->setKey($sharedKey)

--- a/docs/02-PHP-Library/README.md
+++ b/docs/02-PHP-Library/README.md
@@ -89,7 +89,7 @@ $parser = (new Parser())
     ->setKey($sharedKey)
     ->setPurpose('local')
     // Only allow version 2
-    ->setAllowedVersions(ProtocolCollection::default());
+    ->setAllowedVersions(ProtocolCollection::v2());
 
 try {
     $token = $parser->parse($providedToken);

--- a/src/ProtocolCollection.php
+++ b/src/ProtocolCollection.php
@@ -118,4 +118,24 @@ final class ProtocolCollection
             self::WHITELIST
         ));
     }
+
+    /**
+     * Get a collection containing protocol version 1.
+     *
+     * @return self
+     */
+    public static function v1(): self
+    {
+        return new self(new Version1);
+    }
+
+    /**
+     * Get a collection containing protocol version 2.
+     *
+     * @return self
+     */
+    public static function v2(): self
+    {
+        return new self(new Version2);
+    }
 }


### PR DESCRIPTION
I noticed the docs still used the array syntax. I've also added a couple of `ProtocolCollection` named constructors for quickly creating collections of just one protocol version (i.e. to avoid needing to do something like `new ProtocolCollection(new Version2)` now it's `ProtocolCollection::v2()`).

Q: should ProtocolCollection::default() only permit version2? At present it adds all whitelisted protocols (see ef441b0).