### PR TITLE
Remove manually setting nonce from public API

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -428,6 +428,13 @@ class Builder
         switch ($this->purpose) {
             case Purpose::local():
                 if ($this->key instanceof SymmetricKey) {
+                    /**
+                     * During unit tests, perform last-minute dependency
+                     * injection to swap $protocol for a conjured up version.
+                     * This new version can access a protected method on our
+                     * actual $protocol, giving unit tests the ability to
+                     * manually set a pre-decided nonce.
+                     */
                     if (isset($this->unitTestEncrypter)) {
                         /** @var ProtocolInterface */
                         $protocol = ($this->unitTestEncrypter)($protocol);

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -29,8 +29,8 @@ class Builder
     /** @var array<string, string> */
     protected $claims = [];
 
-    /** @var string $explicitNonce -- Do not use this. It's for unit testing! */
-    protected $explicitNonce = '';
+    /** @var \Closure|null $unitTestEncrypter -- Do not use this. It's for unit testing! */
+    protected $unitTestEncrypter;
 
     /** @var SendingKey|null $key */
     protected $key = null;
@@ -255,18 +255,6 @@ class Builder
     }
 
     /**
-     * Do not use this.
-     *
-     * @param string $nonce
-     * @return self
-     */
-    public function setExplicitNonce(string $nonce = ''): self
-    {
-        $this->explicitNonce = $nonce;
-        return $this;
-    }
-
-    /**
      * Set an array of claims in one go.
      *
      * @param array<string, string> $claims
@@ -440,11 +428,15 @@ class Builder
         switch ($this->purpose) {
             case Purpose::local():
                 if ($this->key instanceof SymmetricKey) {
+                    if (isset($this->unitTestEncrypter)) {
+                        /** @var ProtocolInterface */
+                        $protocol = ($this->unitTestEncrypter)($protocol);
+                    }
+
                     $this->cached = (string) $protocol::encrypt(
                         $claims,
                         $this->key,
-                        $this->token->getFooter(),
-                        $this->explicitNonce
+                        $this->token->getFooter()
                     );
                     return $this->cached;
                 }

--- a/src/Protocol/Version1.php
+++ b/src/Protocol/Version1.php
@@ -57,13 +57,32 @@ class Version1 implements ProtocolInterface
      * @param string $data
      * @param SymmetricKey $key
      * @param string $footer
+     * @return string
+     * @throws InvalidVersionException
+     * @throws \SodiumException
+     * @throws \TypeError
+     */
+    public static function encrypt(
+        string $data,
+        SymmetricKey $key,
+        string $footer = ''
+    ): string {
+        return self::__encrypt($data, $key, $footer);
+    }
+
+    /**
+     * Encrypt a message using a shared key.
+     *
+     * @param string $data
+     * @param SymmetricKey $key
+     * @param string $footer
      * @param string $nonceForUnitTesting
      * @return string
      * @throws \Error
      * @throws InvalidVersionException
      * @throws \TypeError
      */
-    public static function encrypt(
+    protected static function __encrypt(
         string $data,
         SymmetricKey $key,
         string $footer = '',

--- a/src/Protocol/Version2.php
+++ b/src/Protocol/Version2.php
@@ -48,13 +48,32 @@ class Version2 implements ProtocolInterface
      * @param string $data
      * @param SymmetricKey $key
      * @param string $footer
-     * @param string $nonceForUnitTesting
      * @return string
      * @throws InvalidVersionException
      * @throws \SodiumException
      * @throws \TypeError
      */
     public static function encrypt(
+        string $data,
+        SymmetricKey $key,
+        string $footer = ''
+    ): string {
+        return self::__encrypt($data, $key, $footer);
+    }
+
+    /**
+     * Encrypt a message using a shared key.
+     *
+     * @param string $data
+     * @param SymmetricKey $key
+     * @param string $footer
+     * @param string $nonceForUnitTesting
+     * @return string
+     * @throws InvalidVersionException
+     * @throws \SodiumException
+     * @throws \TypeError
+     */
+    protected static function __encrypt(
         string $data,
         SymmetricKey $key,
         string $footer = '',

--- a/src/ProtocolInterface.php
+++ b/src/ProtocolInterface.php
@@ -39,8 +39,7 @@ interface ProtocolInterface
     public static function encrypt(
         string $data,
         SymmetricKey $key,
-        string $footer = '',
-        string $nonceForUnitTesting = ''
+        string $footer = ''
     ): string;
 
     /**

--- a/tests/JsonTokenTest.php
+++ b/tests/JsonTokenTest.php
@@ -34,10 +34,11 @@ class JsonTokenTest extends TestCase
         $nonce = Hex::decode('45742c976d684ff84ebdc0de59809a97cda2f64c84fda19b');
         $builder = (new Builder())
             ->setPurpose(Purpose::local())
-            ->setExplicitNonce($nonce)
             ->setKey($key)
             ->set('data', 'this is a signed message')
             ->setExpiration(new \DateTime('2039-01-01T00:00:00+00:00'));
+
+        NonceFixer::buildSetExplicitNonce()->bindTo($builder, $builder)($nonce);
 
         $this->assertSame(
             'v2.local.3fNxan9FHjedQRSONRnT7Ce_KhhpB0NrlHwAGsCb54x0FhrjBfeNN4uPHFiO5H0iPCZSjwfEkkfiGeYpE6KAfr1Zm3G-VTe4lcXtgDyKATYULT-zLPfshRqisk4n7EbGufWuqilYvYXMCiYbaA',
@@ -87,24 +88,25 @@ class JsonTokenTest extends TestCase
         $nonce = Hex::decode('45742c976d684ff84ebdc0de59809a97cda2f64c84fda19b');
         $footerArray = ['key-id' => 'gandalf0'];
 
-        $token = (new Builder())
+        $builder = (new Builder())
             ->setPurpose(Purpose::local())
-            ->setExplicitNonce($nonce)
             ->setKey($key)
             ->set('data', 'this is a signed message')
             ->setExpiration(new \DateTime('2039-01-01T00:00:00+00:00'))
             ->setFooterArray($footerArray);
 
-        $first = (string) $token;
-        $alt = $token->with('data', 'this is a different message');
+        NonceFixer::buildSetExplicitNonce()->bindTo($builder, $builder)($nonce);
+
+        $first = (string) $builder;
+        $alt = $builder->with('data', 'this is a different message');
         $second = (string) $alt;
-        $third = (string) $token;
+        $third = (string) $builder;
 
         $this->assertSame($first, $third);
         $this->assertNotSame($first, $second);
         $this->assertNotSame($second, $third);
 
-        $mutated = $token->withAudience('example.com');
+        $mutated = $builder->withAudience('example.com');
         $mutateTwo = $mutated->withAudience('example.org');
 
         $this->assertNotSame(
@@ -143,11 +145,13 @@ class JsonTokenTest extends TestCase
         $footerArray = ['key-id' => 'gandalf0'];
         $builder = (new Builder())
             ->setPurpose(Purpose::local())
-            ->setExplicitNonce($nonce)
             ->setKey($key)
             ->set('data', 'this is a signed message')
             ->setExpiration(new \DateTime('2039-01-01T00:00:00+00:00'))
             ->setFooterArray($footerArray);
+
+        NonceFixer::buildSetExplicitNonce()->bindTo($builder, $builder)($nonce);
+
         $this->assertSame(
             'v2.local.3fNxan9FHjedQRSONRnT7Ce_KhhpB0NrlHwAGsCb54x0FhrjBfeNN4uPHFiO5H0iPCZSjwfEkkfiGeYpE6KAfr1Zm3G-VTe4lcXtgDyKATYULT-zLPfshRqisk4nZ9JDgBVa-L9vW26CMc57aw.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',
             (string) $builder,

--- a/tests/NonceFixer.php
+++ b/tests/NonceFixer.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\Paseto\Tests;
+
+use ParagonIE\Paseto\ProtocolInterface;
+use ParagonIE\Paseto\Keys\SymmetricKey;
+
+abstract class NonceFixer {
+    public static function buildUnitTestEncrypt(ProtocolInterface $protocol): \Closure {
+        return static function (
+            string $data,
+            SymmetricKey $key,
+            string $footer = '',
+            string $nonceForUnitTesting = ''
+        ) use ($protocol): string {
+            return $protocol::__encrypt($data, $key, $footer, $nonceForUnitTesting);
+        };
+    }
+
+    public static function buildSetExplicitNonce(): \Closure {
+        return function (string $nonce) {
+            $this->unitTestEncrypter = static function (ProtocolInterface $protocol) use ($nonce) {
+                $class = new class {
+                    private static $nonce;
+                    private static $protocol;
+
+                    public static function setNonce(string $nonce)
+                    {
+                        self::$nonce = $nonce;
+                    }
+
+                    public static function setProtocol(ProtocolInterface $protocol)
+                    {
+                        self::$protocol = $protocol;
+                    }
+
+                    public static function encrypt(
+                        string $data,
+                        SymmetricKey $key,
+                        string $footer = ''
+                    ): string {
+                        return NonceFixer::buildUnitTestEncrypt(self::$protocol)->bindTo(null, self::$protocol)(
+                            $data,
+                            $key,
+                            $footer,
+                            self::$nonce
+                        );
+                    }
+                };
+
+                $class::setNonce($nonce);
+                $class::setProtocol($protocol);
+
+                return $class;
+            };
+        };
+    }
+}

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -52,10 +52,11 @@ class ParserTest extends TestCase
         $token = $parser->parse($serialized);
         $v2token = $v2parser->parse($serialized);
 
-        $builder = (Builder::getLocal($key, new Version2(), $token))
-            ->setExplicitNonce($nonce);
-        $v2builder = (Builder::getLocal($v2key, new Version2(), $v2token))
-            ->setExplicitNonce($nonce);
+        $builder = (Builder::getLocal($key, new Version2(), $token));
+        NonceFixer::buildSetExplicitNonce()->bindTo($builder, $builder)($nonce);
+
+        $v2builder = (Builder::getLocal($v2key, new Version2(), $v2token));
+        NonceFixer::buildSetExplicitNonce()->bindTo($v2builder, $v2builder)($nonce);
 
         $this->assertSame(
             '2039-01-01T00:00:00+00:00',

--- a/tests/Version1VectorTest.php
+++ b/tests/Version1VectorTest.php
@@ -35,71 +35,73 @@ class Version1VectorTest extends TestCase
         //$nonce2 = hash('sha256', 'Paragon Initiative Enterprises, LLC', true);
         $nonce2 = Hex::decode('26f7553354482a1d91d4784627854b8da6b8042a7966523c2b404e8dbbe7f7f2');
 
+        $version1Encrypt = NonceFixer::buildUnitTestEncrypt(new Version1)->bindTo(null, new Version1);
+
         // Empty message, empty footer, empty nonce
         $this->assertSame(
             'v1.local.bB8u6Tj60uJL2RKYR0OCyiGMdds9g-EUs9Q2d3bRTTXyNMehtdOLJS_vq4YzYdaZ6vwItmpjx-Lt3AtVanBmiMyzFyqJMHCaWVMpEMUyxUg',
-            Version1::encrypt('', $nullKey, '', $nonce),
+            $version1Encrypt('', $nullKey, '', $nonce),
             'Test Vector 1E-1-1'
         );
         $this->assertSame(
             'v1.local.bB8u6Tj60uJL2RKYR0OCyiGMdds9g-EUs9Q2d3bRTTWgetvu2STfe7gxkDpAOk_IXGmBeea4tGW6HsoH12oKElAWap57-PQMopNurtEoEdk',
-            Version1::encrypt('', $fullKey, '', $nonce),
+            $version1Encrypt('', $fullKey, '', $nonce),
             'Test Vector 1E-1-2'
         );
         $this->assertSame(
             'v1.local.bB8u6Tj60uJL2RKYR0OCyiGMdds9g-EUs9Q2d3bRTTV8OmiMvoZgzer20TE8kb3R0QN9Ay-ICSkDD1-UDznTCdBiHX1fbb53wdB5ng9nCDY',
-            Version1::encrypt('', $symmetricKey, '', $nonce),
+            $version1Encrypt('', $symmetricKey, '', $nonce),
             'Test Vector 1E-1-3'
         );
 
         // Empty message, non-empty footer, empty nonce
         $this->assertSame(
             'v1.local.bB8u6Tj60uJL2RKYR0OCyiGMdds9g-EUs9Q2d3bRTTVhyXOB4vmrFm9GvbJdMZGArV5_10Kxwlv4qSb-MjRGgFzPg00-T2TCFdmc9BMvJAA.Q3VvbiBBbHBpbnVz',
-            Version1::encrypt('', $nullKey, 'Cuon Alpinus', $nonce),
+            $version1Encrypt('', $nullKey, 'Cuon Alpinus', $nonce),
             'Test Vector 1E-2-1'
         );
         $this->assertSame(
             'v1.local.bB8u6Tj60uJL2RKYR0OCyiGMdds9g-EUs9Q2d3bRTTVna3s7WqUwfQaVM8ddnvjPkrWkYRquX58-_RgRQTnHn7hwGJwKT3H23ZDlioSiJeo.Q3VvbiBBbHBpbnVz',
-            Version1::encrypt('', $fullKey, 'Cuon Alpinus', $nonce),
+            $version1Encrypt('', $fullKey, 'Cuon Alpinus', $nonce),
             'Test Vector 1E-2-2'
         );
         $this->assertSame(
             'v1.local.bB8u6Tj60uJL2RKYR0OCyiGMdds9g-EUs9Q2d3bRTTW9MRfGNyfC8vRpl8xsgnsWt-zHinI9bxLIVF0c6INWOv0_KYIYEaZjrtumY8cyo7M.Q3VvbiBBbHBpbnVz',
-            Version1::encrypt('', $symmetricKey, 'Cuon Alpinus', $nonce),
+            $version1Encrypt('', $symmetricKey, 'Cuon Alpinus', $nonce),
             'Test Vector 1E-2-3'
         );
 
         // Non-empty message, empty footer, empty nonce
         $this->assertSame(
             'v1.local.N9n3wL3RJUckyWdg4kABZeMwaAfzNT3B64lhyx7QA45LtwQCqG8LYmNfBHIX-4Uxfm8KzaYAUUHqkxxv17MFxsEvk-Ex67g9P-z7EBFW09xxSt21Xm1ELB6pxErl4RE1gGtgvAm9tl3rW2-oy6qHlYx2',
-            Version1::encrypt('Love is stronger than hate or fear', $nullKey, '', $nonce),
+            $version1Encrypt('Love is stronger than hate or fear', $nullKey, '', $nonce),
             'Test Vector 1E-3-1'
         );
         $this->assertSame(
             'v1.local.N9n3wL3RJUckyWdg4kABZeMwaAfzNT3B64lhyx7QA47lQ79wMmeM7sC4c0-BnsXzIteEQQBQpu_FyMznRnzYg4gN-6Kt50rXUxgPPfwDpOr3lUb5U16RzIGrMNemKy0gRhfKvAh1b8N57NKk93pZLpEz',
-            Version1::encrypt('Love is stronger than hate or fear', $fullKey, '', $nonce),
+            $version1Encrypt('Love is stronger than hate or fear', $fullKey, '', $nonce),
             'Test Vector 1E-3-2'
         );
         $this->assertSame(
             'v1.local.N9n3wL3RJUckyWdg4kABZeMwaAfzNT3B64lhyx7QA47hvAicYf1zfZrxPrLeBFdbEKO3JRQdn3gjqVEkR1aXXttscmmZ6t48tfuuudETldFD_xbqID74_TIDO1JxDy7OFgYI_PehxzcapQ8t040Fgj9k',
-            Version1::encrypt('Love is stronger than hate or fear', $symmetricKey, '', $nonce),
+            $version1Encrypt('Love is stronger than hate or fear', $symmetricKey, '', $nonce),
             'Test Vector 1E-3-3'
         );
 
         // Non-empty message, non-empty footer, non-empty nonce
         $this->assertSame(
             'v1.local.rElw-WywOuwAqKC9Yao3YokSp7vx0YiUB9hLTnsVOYbivwqsESBnr82_ZoMFFGzolJ6kpkOihkulB4K_JhfMHoFw4E9yCR6ltWX3e9MTNSud8mpBzZiwNXNbgXBLxF_Igb5Ixo_feIonmCucOXDlLVUT.Q3VvbiBBbHBpbnVz',
-            Version1::encrypt('Love is stronger than hate or fear', $nullKey, 'Cuon Alpinus', $nonce2),
+            $version1Encrypt('Love is stronger than hate or fear', $nullKey, 'Cuon Alpinus', $nonce2),
             'Test Vector 1E-4-1'
         );
         $this->assertSame(
             'v1.local.rElw-WywOuwAqKC9Yao3YokSp7vx0YiUB9hLTnsVOYZ8rQTA12SNb9cY8jVtVyikY2jj_tEBzY5O7GJsxb5MdQ6cMSnDz2uJGV20vhzVDgvkjdEcN9D44VaHid26qy1_1YlHjU6pmyTmJt8WT21LqzDl.Q3VvbiBBbHBpbnVz',
-            Version1::encrypt('Love is stronger than hate or fear', $fullKey, 'Cuon Alpinus', $nonce2),
+            $version1Encrypt('Love is stronger than hate or fear', $fullKey, 'Cuon Alpinus', $nonce2),
             'Test Vector 1E-4-2'
         );
         $this->assertSame(
             'v1.local.rElw-WywOuwAqKC9Yao3YokSp7vx0YiUB9hLTnsVOYYTojmVaYumJSQt8aggtCaFKWyaodw5k-CUWhYKATopiabAl4OAmTxHCfm2E4NSPvrmMcmi8n-JcZ93HpcxC6rx_ps22vutv7iP7wf8QcSD1Mwx.Q3VvbiBBbHBpbnVz',
-            Version1::encrypt('Love is stronger than hate or fear', $symmetricKey, 'Cuon Alpinus', $nonce2),
+            $version1Encrypt('Love is stronger than hate or fear', $symmetricKey, 'Cuon Alpinus', $nonce2),
             'Test Vector 1E-4-3'
         );
     }

--- a/tests/Version2VectorTest.php
+++ b/tests/Version2VectorTest.php
@@ -82,71 +82,73 @@ class Version2VectorTest extends TestCase
         // $nonce2 = sodium_crypto_generichash('Paragon Initiative Enterprises, LLC', '', 24);
         $nonce2 = Hex::decode('45742c976d684ff84ebdc0de59809a97cda2f64c84fda19b');
 
+        $version2Encrypt = NonceFixer::buildUnitTestEncrypt(new Version2)->bindTo(null, new Version2);
+
         // Empty message, empty footer, empty nonce
         $this->assertSame(
             'v2.local.driRNhM20GQPvlWfJCepzh6HdijAq-yNUtKpdy5KXjKfpSKrOlqQvQ',
-            Version2::encrypt('', $this->nullKey, '', $nonce),
+            $version2Encrypt('', $this->nullKey, '', $nonce),
             'Test Vector 2E-1-1'
         );
         $this->assertSame(
             'v2.local.driRNhM20GQPvlWfJCepzh6HdijAq-yNSOvpveyCsjPYfe9mtiJDVg',
-            Version2::encrypt('', $this->fullKey, '', $nonce),
+            $version2Encrypt('', $this->fullKey, '', $nonce),
             'Test Vector 2E-1-2'
         );
         $this->assertSame(
             'v2.local.driRNhM20GQPvlWfJCepzh6HdijAq-yNkIWACdHuLiJiW16f2GuGYA',
-            Version2::encrypt('', $this->symmetricKey, '', $nonce),
+            $version2Encrypt('', $this->symmetricKey, '', $nonce),
             'Test Vector 2E-1-3'
         );
 
         // Empty message, non-empty footer, empty nonce
         $this->assertSame(
             'v2.local.driRNhM20GQPvlWfJCepzh6HdijAq-yNfzz6yGkE4ZxojJAJwKLfvg.Q3VvbiBBbHBpbnVz',
-            Version2::encrypt('', $this->nullKey, 'Cuon Alpinus', $nonce),
+            $version2Encrypt('', $this->nullKey, 'Cuon Alpinus', $nonce),
             'Test Vector 2E-2-1'
         );
         $this->assertSame(
             'v2.local.driRNhM20GQPvlWfJCepzh6HdijAq-yNJbTJxAGtEg4ZMXY9g2LSoQ.Q3VvbiBBbHBpbnVz',
-            Version2::encrypt('', $this->fullKey, 'Cuon Alpinus', $nonce),
+            $version2Encrypt('', $this->fullKey, 'Cuon Alpinus', $nonce),
             'Test Vector 2E-2-2'
         );
         $this->assertSame(
             'v2.local.driRNhM20GQPvlWfJCepzh6HdijAq-yNreCcZAS0iGVlzdHjTf2ilg.Q3VvbiBBbHBpbnVz',
-            Version2::encrypt('', $this->symmetricKey, 'Cuon Alpinus', $nonce),
+            $version2Encrypt('', $this->symmetricKey, 'Cuon Alpinus', $nonce),
             'Test Vector 2E-2-3'
         );
 
         // Non-empty message, empty footer, empty nonce
         $this->assertSame(
             'v2.local.BEsKs5AolRYDb_O-bO-lwHWUextpShFSvu6cB-KuR4wR9uDMjd45cPiOF0zxb7rrtOB5tRcS7dWsFwY4ONEuL5sWeunqHC9jxU0',
-            Version2::encrypt('Love is stronger than hate or fear', $this->nullKey, '', $nonce),
+            $version2Encrypt('Love is stronger than hate or fear', $this->nullKey, '', $nonce),
             'Test Vector 2E-3-1'
         );
         $this->assertSame(
             'v2.local.BEsKs5AolRYDb_O-bO-lwHWUextpShFSjvSia2-chHyMi4LtHA8yFr1V7iZmKBWqzg5geEyNAAaD6xSEfxoET1xXqahe1jqmmPw',
-            Version2::encrypt('Love is stronger than hate or fear', $this->fullKey, '', $nonce),
+            $version2Encrypt('Love is stronger than hate or fear', $this->fullKey, '', $nonce),
             'Test Vector 2E-3-2'
         );
         $this->assertSame(
             'v2.local.BEsKs5AolRYDb_O-bO-lwHWUextpShFSXlvv8MsrNZs3vTSnGQG4qRM9ezDl880jFwknSA6JARj2qKhDHnlSHx1GSCizfcF019U',
-            Version2::encrypt('Love is stronger than hate or fear', $this->symmetricKey, '', $nonce),
+            $version2Encrypt('Love is stronger than hate or fear', $this->symmetricKey, '', $nonce),
             'Test Vector 2E-3-3'
         );
 
         // Non-empty message, non-empty footer, non-empty nonce
         $this->assertSame(
             'v2.local.FGVEQLywggpvH0AzKtLXz0QRmGYuC6yvbcqXgWxM3vJGrJ9kWqquP61Xl7bz4ZEqN5XwH7xyzV0QqPIo0k52q5sWxUQ4LMBFFso.Q3VvbiBBbHBpbnVz',
-            Version2::encrypt('Love is stronger than hate or fear', $this->nullKey, 'Cuon Alpinus', $nonce2),
+            $version2Encrypt('Love is stronger than hate or fear', $this->nullKey, 'Cuon Alpinus', $nonce2),
             'Test Vector 2E-4-1'
         );
         $this->assertSame(
             'v2.local.FGVEQLywggpvH0AzKtLXz0QRmGYuC6yvZMW3MgUMFplQXsxcNlg2RX8LzFxAqj4qa2FwgrUdH4vYAXtCFrlGiLnk-cHHOWSUSaw.Q3VvbiBBbHBpbnVz',
-            Version2::encrypt('Love is stronger than hate or fear', $this->fullKey, 'Cuon Alpinus', $nonce2),
+            $version2Encrypt('Love is stronger than hate or fear', $this->fullKey, 'Cuon Alpinus', $nonce2),
             'Test Vector 2E-4-2'
         );
         $this->assertSame(
             'v2.local.FGVEQLywggpvH0AzKtLXz0QRmGYuC6yvl05z9GIX0cnol6UK94cfV77AXnShlUcNgpDR12FrQiurS8jxBRmvoIKmeMWC5wY9Y6w.Q3VvbiBBbHBpbnVz',
-            Version2::encrypt('Love is stronger than hate or fear', $this->symmetricKey, 'Cuon Alpinus', $nonce2),
+            $version2Encrypt('Love is stronger than hate or fear', $this->symmetricKey, 'Cuon Alpinus', $nonce2),
             'Test Vector 2E-4-3'
         );
 
@@ -154,7 +156,7 @@ class Version2VectorTest extends TestCase
         $footer = 'Paragon Initiative Enterprises';
         $this->assertSame(
             'v2.local.lClhzVOuseCWYep44qbA8rmXry66lUupyENijX37_I_z34EiOlfyuwqIIhOjF-e9m2J-Qs17Gs-BpjpLlh3zf-J37n7YGHqMBV6G5xD2aeIKpck6rhfwHpGF38L7ryYuzuUeqmPg8XozSfU4PuPp9o8.UGFyYWdvbiBJbml0aWF0aXZlIEVudGVycHJpc2Vz',
-            Version2::encrypt($message, $this->symmetricKey, $footer, $nonce2),
+            $version2Encrypt($message, $this->symmetricKey, $footer, $nonce2),
             'Test Vector 2E-5'
         );
     }


### PR DESCRIPTION
Do bad a thing in the tests to remove a footgun from the public API.