### PR TITLE
Move parser message deconstruction into dedicated implementation

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -184,9 +184,8 @@ class Parser
         }
 
         // First, check against the user's specified list of allowed versions.
-        $header = $pieces[0];
         /** @var ProtocolInterface $protocol */
-        $protocol = ProtocolCollection::protocolFromHeader($header);
+        $protocol = ProtocolCollection::protocolFromHeaderPart($pieces[0]);
         if (!$this->allowedVersions->has($protocol)) {
             throw new InvalidVersionException('Disallowed or unsupported version');
         }

--- a/src/Parsing/Header.php
+++ b/src/Parsing/Header.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\Paseto\Parsing;
+
+use ParagonIE\Paseto\{
+    ProtocolInterface,
+    ProtocolCollection,
+    Purpose
+};
+
+final class Header
+{
+    /**
+     * @var ProtocolInterface
+     */
+    private $protocol;
+
+    /**
+     * @var Purpose
+     */
+    private $purpose;
+
+    /**
+     * Validate message header strings
+     *
+     * @param string $protocol      Tainted user-provided string.
+     * @param string $purpose      Tainted user-provided string.
+     *
+     * @throws InvalidVersionException
+     * @throws InvalidPurposeException
+     */
+    public function __construct(string $protocol, string $purpose)
+    {
+        $this->protocol = ProtocolCollection::protocolFromHeaderPart($protocol);
+        $this->purpose  = new Purpose($purpose);
+    }
+
+    public function protocol(): ProtocolInterface
+    {
+        return $this->protocol;
+    }
+
+    public function purpose(): Purpose
+    {
+        return $this->purpose;
+    }
+}

--- a/src/Parsing/PasetoMessage.php
+++ b/src/Parsing/PasetoMessage.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\Paseto\Parsing;
+
+use ParagonIE\Paseto\Exception\{
+    SecurityException,
+    InvalidVersionException,
+    InvalidPurposeException
+};
+
+final class PasetoMessage
+{
+    /**
+     * @var Header
+     */
+
+    private $header;
+    /**
+     * @var string
+     */
+    private $encodedPayload;
+
+    /**
+     * @var string
+     */
+    private $encodedFooter;
+
+    /**
+     * Parse a string into a deconstructed PasetoMessage object.
+     *
+     * @param string $tainted      Tainted user-provided string.
+     *
+     * @throws SecurityException
+     * @throws InvalidVersionException
+     * @throws InvalidPurposeException
+     */
+    public function __construct(string $tainted)
+    {
+        /** @var array<int, string> $pieces */
+        $pieces = \explode('.', $tainted);
+        $count = \count($pieces);
+        if ($count < 3 || $count > 4) {
+            throw new SecurityException('Truncated or invalid token');
+        }
+
+        $this->header = new Header($pieces[0], $pieces[1]);
+        $this->encodedPayload = $pieces[2];
+        $this->encodedFooter = $count > 3 ? $pieces[3] : '';
+    }
+
+    public function header(): Header
+    {
+        return $this->header;
+    }
+
+    public function encodedPayload(): string
+    {
+        return $this->encodedPayload;
+    }
+
+    public function encodedFooter(): string
+    {
+        return $this->encodedFooter;
+    }
+}

--- a/src/ProtocolCollection.php
+++ b/src/ProtocolCollection.php
@@ -84,13 +84,13 @@ final class ProtocolCollection
     }
 
     /**
-     * @param string $header
+     * @param string $headerPart
      * @return ProtocolInterface
      * @throws InvalidVersionException
      * @psalm-suppress UndefinedClass  A BC break introduced in Psalm v1.0.2
      *                                 stopped respecting what we were doing.
      */
-    public static function protocolFromHeader(string $header): ProtocolInterface {
+    public static function protocolFromHeaderPart(string $headerPart): ProtocolInterface {
         if (empty(self::$headerLookup)) {
             /** @var ProtocolInterface $protocolClass */
             foreach (self::WHITELIST as $protocolClass) {
@@ -98,11 +98,11 @@ final class ProtocolCollection
             }
         }
 
-        if (!\array_key_exists($header, self::$headerLookup)) {
+        if (!\array_key_exists($headerPart, self::$headerLookup)) {
             throw new InvalidVersionException('Disallowed or unsupported version');
         }
 
-        return self::$headerLookup[$header];
+        return self::$headerLookup[$headerPart];
     }
 
     /**


### PR DESCRIPTION
This is me basically just ripping this out in its PHP equivalent form

https://github.com/aidantwoods/swift-paseto/blob/f39f8a0c639c18fbeb417b4a52a5ff9c1115294d/Sources/Paseto/Blob.swift#L39-L54
![screen shot 2018-03-14 at 00 01 35](https://user-images.githubusercontent.com/3288888/37376140-e6bfa4ac-271a-11e8-9b14-d2d9e2eb8e01.png)


I found it useful for creating a "take a peak at the header" convenience function, and it serves to basically do that here except for the footer (to avoid duplicating the parsing code).
https://github.com/aidantwoods/swift-paseto/blob/f39f8a0c639c18fbeb417b4a52a5ff9c1115294d/Sources/Paseto/Util.swift#L24-L27
![screen shot 2018-03-14 at 00 02 44](https://user-images.githubusercontent.com/3288888/37376173-0dadb7b6-271b-11e8-8237-b94a1945ba89.png)

In-fact it also serves to separate message deconstruction from the validation specifics inherited by the parser object settings too.

---

If there is appetite, its possible to actually take this a little further and defer to a shared message deconstruction implementation within the protocols too, e.g. something like
https://github.com/aidantwoods/swift-paseto/blob/f39f8a0c639c18fbeb417b4a52a5ff9c1115294d/Sources/Paseto/Implementations/Version2.swift#L58-L78
![screen shot 2018-03-14 at 00 05 03](https://user-images.githubusercontent.com/3288888/37376333-a74b6b52-271b-11e8-92a3-8e5e2ef6a907.png)

This would basically involve creating a intermediary object that can create itself from the Paseto message format, and serialise itself back into it (that way we centralise the construction of messages away from individual implementations too). Then we can pass that to `decrypt` and `verify` methods, and it could be produced by `encrypt` and `sign` methods. The new `PasetoMessage` object in this PR is almost capable of being that intermediary object (sans a serialisation implementation).

The end result would be a little more verbose in PHP as you'd have to check the header validity manually where it matters (in the above implementation header correctness is enforced by choice of type parameters).

---

This also fixes the issue pointed out in https://github.com/paragonie/paseto/commit/2d3d70d102c58c7267f0544a8ed4218bbf53712b#r28076938 by @rlittlefield. Apparently the parser has somehow been getting away without having any test cases that have a footer in public mode 😆 
(test cases filling this gap still need to be added)
