### PR TITLE
Fix bug where footer of value of "0" would not be included in message

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -2,7 +2,6 @@
 declare(strict_types=1);
 namespace ParagonIE\Paseto;
 
-use ParagonIE\ConstantTime\Base64UrlSafe;
 use ParagonIE\Paseto\Exception\{
     EncodingException,
     InvalidKeyException,
@@ -80,9 +79,7 @@ class Parser
      */
     public static function extractFooter(string $tainted): string
     {
-        return Base64UrlSafe::decode(
-            (new PasetoMessage($tainted))->encodedFooter()
-        );
+        return (new PasetoMessage($tainted))->footer();
     }
 
     /**
@@ -165,7 +162,7 @@ class Parser
         }
 
         /** @var Purpose $purpose */
-        $footer = Base64UrlSafe::decode($parsed->encodedFooter());
+        $footer = $parsed->footer();
         $purpose = $parsed->header()->purpose();
 
         // $this->purpose is not mandatory, but if it's set, verify against it.

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -79,7 +79,7 @@ class Parser
      */
     public static function extractFooter(string $tainted): string
     {
-        return (new PasetoMessage($tainted))->footer();
+        return PasetoMessage::fromString($tainted)->footer();
     }
 
     /**
@@ -152,7 +152,7 @@ class Parser
      */
     public function parse(string $tainted, bool $skipValidation = false): JsonToken
     {
-        $parsed = new PasetoMessage($tainted);
+        $parsed = PasetoMessage::fromString($tainted);
 
         // First, check against the user's specified list of allowed versions.
         /** @var ProtocolInterface $protocol */

--- a/src/Parsing/Header.php
+++ b/src/Parsing/Header.php
@@ -50,4 +50,11 @@ final class Header
     {
         return $this->purpose;
     }
+
+    public function toString(): string
+    {
+        return $this->protocol->header() . "."
+            . $this->purpose->rawString() . "."
+        ;
+    }
 }

--- a/src/Parsing/Header.php
+++ b/src/Parsing/Header.php
@@ -41,6 +41,26 @@ final class Header
         $this->purpose  = new Purpose($purpose);
     }
 
+    /**
+     * Parse a string into a deconstructed Header object.
+     *
+     * @param string $tainted      Tainted user-provided string.
+     * @return self
+     * @throws SecurityException
+     */
+    public static function fromString(string $tainted): self
+    {
+        /** @var array<int, string> $pieces */
+        $pieces = \explode('.', $tainted);
+        $count = \count($pieces);
+        if ($count !== 3 or $pieces[2] !== '') {
+            // we expect "version.purpose." format
+            throw new SecurityException('Truncated or invalid header');
+        }
+
+        return new Header($pieces[0], $pieces[1]);
+    }
+
     public function protocol(): ProtocolInterface
     {
         return $this->protocol;

--- a/src/Parsing/Header.php
+++ b/src/Parsing/Header.php
@@ -5,6 +5,7 @@ namespace ParagonIE\Paseto\Parsing;
 use ParagonIE\Paseto\{
     Exception\InvalidPurposeException,
     Exception\InvalidVersionException,
+    Exception\SecurityException,
     ProtocolInterface,
     ProtocolCollection,
     Purpose

--- a/src/Parsing/PasetoMessage.php
+++ b/src/Parsing/PasetoMessage.php
@@ -70,4 +70,17 @@ final class PasetoMessage
     {
         return $this->footer;
     }
+
+    public function toString(): string
+    {
+        $message =  $this->header->toString()
+            . Base64UrlSafe::encodeUnpadded($this->payload)
+        ;
+
+        if ($this->footer === '') {
+            return $message;
+        }
+
+        return $message . "." . Base64UrlSafe::encodeUnpadded($this->footer);
+    }
 }

--- a/src/Parsing/PasetoMessage.php
+++ b/src/Parsing/PasetoMessage.php
@@ -24,6 +24,13 @@ final class PasetoMessage
     /** @var string */
     private $footer;
 
+    public function __construct(Header $header, string $payload, string $footer)
+    {
+        $this->header  = $header;
+        $this->payload = $payload;
+        $this->footer  = $footer;
+    }
+
     /**
      * Parse a string into a deconstructed PasetoMessage object.
      *
@@ -33,7 +40,7 @@ final class PasetoMessage
      * @throws InvalidVersionException
      * @throws InvalidPurposeException
      */
-    public function __construct(string $tainted)
+    public static function fromString(string $tainted): self
     {
         /** @var array<int, string> $pieces */
         $pieces = \explode('.', $tainted);
@@ -42,9 +49,11 @@ final class PasetoMessage
             throw new SecurityException('Truncated or invalid token');
         }
 
-        $this->header = new Header($pieces[0], $pieces[1]);
-        $this->payload = Base64UrlSafe::decode($pieces[2]);
-        $this->footer = $count > 3 ? Base64UrlSafe::decode($pieces[3]) : '';
+        $header = new Header($pieces[0], $pieces[1]);
+        $payload = Base64UrlSafe::decode($pieces[2]);
+        $footer = $count > 3 ? Base64UrlSafe::decode($pieces[3]) : '';
+
+        return new self($header, $payload, $footer);
     }
 
     public function header(): Header

--- a/src/Parsing/PasetoMessage.php
+++ b/src/Parsing/PasetoMessage.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\Paseto\Parsing;
 
+use ParagonIE\ConstantTime\Base64UrlSafe;
 use ParagonIE\Paseto\Exception\{
     SecurityException,
     InvalidVersionException,
@@ -18,10 +19,10 @@ final class PasetoMessage
     private $header;
 
     /** @var string */
-    private $encodedPayload;
+    private $payload;
 
     /** @var string */
-    private $encodedFooter;
+    private $footer;
 
     /**
      * Parse a string into a deconstructed PasetoMessage object.
@@ -42,8 +43,8 @@ final class PasetoMessage
         }
 
         $this->header = new Header($pieces[0], $pieces[1]);
-        $this->encodedPayload = $pieces[2];
-        $this->encodedFooter = $count > 3 ? $pieces[3] : '';
+        $this->payload = Base64UrlSafe::decode($pieces[2]);
+        $this->footer = $count > 3 ? Base64UrlSafe::decode($pieces[3]) : '';
     }
 
     public function header(): Header
@@ -51,13 +52,13 @@ final class PasetoMessage
         return $this->header;
     }
 
-    public function encodedPayload(): string
+    public function payload(): string
     {
-        return $this->encodedPayload;
+        return $this->payload;
     }
 
-    public function encodedFooter(): string
+    public function footer(): string
     {
-        return $this->encodedFooter;
+        return $this->footer;
     }
 }

--- a/src/Protocol/Version1.php
+++ b/src/Protocol/Version1.php
@@ -20,6 +20,10 @@ use ParagonIE\Paseto\{
     ProtocolInterface,
     Util
 };
+use ParagonIE\Paseto\Parsing\{
+    Header,
+    PasetoMessage
+};
 use phpseclib\Crypt\RSA;
 
 /**
@@ -146,13 +150,12 @@ class Version1 implements ProtocolInterface
         $signature = $rsa->sign(
             Util::preAuthEncode($header, $data, $footer)
         );
-        if ($footer) {
-            return $header .
-                Base64UrlSafe::encodeUnpadded($data . $signature) .
-                '.' .
-                Base64UrlSafe::encodeUnpadded($footer);
-        }
-        return $header . Base64UrlSafe::encodeUnpadded($data . $signature);
+
+        return (new PasetoMessage(
+            Header::fromString($header),
+            $data . $signature,
+            $footer
+        ))->toString();
     }
 
     /**
@@ -240,13 +243,12 @@ class Version1 implements ProtocolInterface
             $authKey,
             true
         );
-        if ($footer) {
-            return $header .
-                Base64UrlSafe::encodeUnpadded($nonce . $ciphertext . $mac) .
-                '.' .
-                Base64UrlSafe::encodeUnpadded($footer);
-        }
-        return $header . Base64UrlSafe::encodeUnpadded($nonce . $ciphertext . $mac);
+
+        return (new PasetoMessage(
+            Header::fromString($header),
+            $nonce . $ciphertext . $mac,
+            $footer
+        ))->toString();
     }
 
     /**

--- a/src/Protocol/Version2.php
+++ b/src/Protocol/Version2.php
@@ -19,6 +19,10 @@ use ParagonIE\Paseto\{
     ProtocolInterface,
     Util
 };
+use ParagonIE\Paseto\Parsing\{
+    Header,
+    PasetoMessage
+};
 
 /**
  * Class Version1
@@ -146,13 +150,12 @@ class Version2 implements ProtocolInterface
             Util::preAuthEncode($header, $data, $footer),
             $key->raw()
         );
-        if ($footer) {
-            return $header .
-                Base64UrlSafe::encodeUnpadded($data . $signature) .
-                '.' .
-                Base64UrlSafe::encodeUnpadded($footer);
-        }
-        return $header . Base64UrlSafe::encodeUnpadded($data . $signature);
+
+        return (new PasetoMessage(
+            Header::fromString($header),
+            $data . $signature,
+            $footer
+        ))->toString();
     }
 
     /**
@@ -243,13 +246,12 @@ class Version2 implements ProtocolInterface
             $nonce,
             $key->raw()
         );
-        if ($footer) {
-            return $header .
-                Base64UrlSafe::encodeUnpadded($nonce . $ciphertext) .
-                '.' .
-                Base64UrlSafe::encodeUnpadded($footer);
-        }
-        return $header . Base64UrlSafe::encodeUnpadded($nonce . $ciphertext);
+
+        return (new PasetoMessage(
+            Header::fromString($header),
+            $nonce . $ciphertext,
+            $footer
+        ))->toString();
     }
 
     /**


### PR DESCRIPTION
`if ($footer)` will fail when the string is falsey (I think the only non-empty possibility is the string `"0"`).
The signed/encrypted payload would account for the footer in the signature/mac/additional data, but the footer would not be included in the message format – which would cause verification of messages to fail (since a parser would not have a footer to read).

---

I also took this opportunity to move building of the message from its components into a centralised location.