### PR TITLE
Fixed typo in test vector name

### DIFF
--- a/tests/Version2VectorTest.php
+++ b/tests/Version2VectorTest.php
@@ -301,7 +301,7 @@ class Version2VectorTest extends TestCase
         $this->assertSame(
             'v2.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAxOS0wMS0wMVQwMDowMDowMCswMDowMCJ9flsZsx_gYCR0N_Ec2QxJFFpvQAs7h9HtKwbVK2n1MJ3Rz-hwe8KUqjnd8FAnIJZ601tp7lGkguU63oGbomhoBw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9',
             Version2::sign($message, $this->privateKey, $footer),
-            'Test Vector 2E-6'
+            'Test Vector S-7'
         );
     }
 }


### PR DESCRIPTION
Just a small typo fix. The name of this test vector looks incorrect from the context.