### PR TITLE
Fix preAuthEncode on 32-bit PHP

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -117,10 +117,10 @@ abstract class Util
      */
     public static function preAuthEncode(string ...$pieces): string
     {
-        $accumulator = \pack('P', \count($pieces) & PHP_INT_MAX);
+        $accumulator = \ParagonIE_Sodium_Core_Util::store64_le(\count($pieces) & PHP_INT_MAX);
         foreach ($pieces as $piece) {
             $len = Binary::safeStrlen($piece);
-            $accumulator .= \pack('P', $len & PHP_INT_MAX);
+            $accumulator .= \ParagonIE_Sodium_Core_Util::store64_le($len & PHP_INT_MAX);
             $accumulator .= $piece;
         }
         return $accumulator;


### PR DESCRIPTION
32-bit PHP does not support the `P` format for `pack()`, thus fails with:
`pack(): 64-bit format codes are not available for 32-bit versions of PHP`

Fix by using the `store64_le` function from sodium_compat. Related fix
there: https://github.com/paragonie/sodium_compat/issues/60