### PR TITLE
Allow DateTimeImmutable everywhere

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -196,10 +196,10 @@ class Builder
     /**
      * Set the 'iat' claim for the token we're building. (Mutable.)
      *
-     * @param \DateTime|null $time
+     * @param \DateTimeInterface|null $time
      * @return self
      */
-    public function setIssuedAt(\DateTime $time = null): self
+    public function setIssuedAt(\DateTimeInterface $time = null): self
     {
         if (!$time) {
             $time = new \DateTime('NOW');
@@ -232,10 +232,10 @@ class Builder
     /**
      * Set the 'nbf' claim for the token we're building. (Mutable.)
      *
-     * @param \DateTime|null $time
+     * @param \DateTimeInterface|null $time
      * @return self
      */
-    public function setNotBefore(\DateTime $time = null): self
+    public function setNotBefore(\DateTimeInterface $time = null): self
     {
         if (!$time) {
             $time = new \DateTime('NOW');
@@ -506,10 +506,10 @@ class Builder
     /**
      * Return a new Builder instance with a changed 'exp' claim.
      *
-     * @param \DateTime|null $time
+     * @param \DateTimeInterface|null $time
      * @return self
      */
-    public function withExpiration(\DateTime $time = null): self
+    public function withExpiration(\DateTimeInterface $time = null): self
     {
         return (clone $this)->setExpiration($time);
     }
@@ -541,10 +541,10 @@ class Builder
     /**
      * Return a new Builder instance with a changed 'iat' claim.
      *
-     * @param \DateTime|null $time
+     * @param \DateTimeInterface|null $time
      * @return self
      */
-    public function withIssuedAt(\DateTime $time = null): self
+    public function withIssuedAt(\DateTimeInterface $time = null): self
     {
         return (clone $this)->setIssuedAt($time);
     }
@@ -574,10 +574,10 @@ class Builder
     /**
      * Return a new Builder instance with a changed 'nbf' claim.
      *
-     * @param \DateTime|null $time
+     * @param \DateTimeInterface|null $time
      * @return self
      */
-    public function withNotBefore(\DateTime $time = null): self
+    public function withNotBefore(\DateTimeInterface $time = null): self
     {
         return (clone $this)->setNotBefore($time);
     }

--- a/src/JsonToken.php
+++ b/src/JsonToken.php
@@ -201,10 +201,10 @@ class JsonToken
     /**
      * Set the 'exp' claim.
      *
-     * @param \DateTime|null $time
+     * @param \DateTimeInterface|null $time
      * @return self
      */
-    public function setExpiration(\DateTime $time = null): self
+    public function setExpiration(\DateTimeInterface $time = null): self
     {
         if (!$time) {
             $time = new \DateTime('NOW');
@@ -244,10 +244,10 @@ class JsonToken
     /**
      * Set the 'iat' claim.
      *
-     * @param \DateTime|null $time
+     * @param \DateTimeInterface|null $time
      * @return self
      */
-    public function setIssuedAt(\DateTime $time = null): self
+    public function setIssuedAt(\DateTimeInterface $time = null): self
     {
         if (!$time) {
             $time = new \DateTime('NOW');
@@ -283,10 +283,10 @@ class JsonToken
     /**
      * Set the 'nbf' claim.
      *
-     * @param \DateTime|null $time
+     * @param \DateTimeInterface|null $time
      * @return self
      */
-    public function setNotBefore(\DateTime $time = null): self
+    public function setNotBefore(\DateTimeInterface $time = null): self
     {
         if (!$time) {
             $time = new \DateTime('NOW');
@@ -344,10 +344,10 @@ class JsonToken
     /**
      * Return a new JsonToken instance with a changed 'exp' claim.
      *
-     * @param \DateTime|null $time
+     * @param \DateTimeInterface|null $time
      * @return self
      */
-    public function withExpiration(\DateTime $time = null): self
+    public function withExpiration(\DateTimeInterface $time = null): self
     {
         return (clone $this)->setExpiration($time);
     }
@@ -379,10 +379,10 @@ class JsonToken
     /**
      * Return a new JsonToken instance with a changed 'iat' claim.
      *
-     * @param \DateTime|null $time
+     * @param \DateTimeInterface|null $time
      * @return self
      */
-    public function withIssuedAt(\DateTime $time = null): self
+    public function withIssuedAt(\DateTimeInterface $time = null): self
     {
         return (clone $this)->setIssuedAt($time);
     }
@@ -412,10 +412,10 @@ class JsonToken
     /**
      * Return a new JsonToken instance with a changed 'nbf' claim.
      *
-     * @param \DateTime|null $time
+     * @param \DateTimeInterface|null $time
      * @return self
      */
-    public function withNotBefore(\DateTime $time = null): self
+    public function withNotBefore(\DateTimeInterface $time = null): self
     {
         return (clone $this)->setNotBefore($time);
     }

--- a/src/Rules/NotExpired.php
+++ b/src/Rules/NotExpired.php
@@ -17,14 +17,14 @@ class NotExpired implements ValidationRuleInterface
     /** @var string $failure */
     protected $failure = 'OK';
 
-    /** @var \DateTime $now */
+    /** @var \DateTimeInterface $now */
     protected $now;
 
     /**
      * NotExpired constructor.
-     * @param \DateTime|null $now Allows "now" to be overwritten for unit testing
+     * @param \DateTimeInterface|null $now Allows "now" to be overwritten for unit testing
      */
-    public function __construct(\DateTime $now = null)
+    public function __construct(\DateTimeInterface $now = null)
     {
         if (!$now) {
             $now = new \DateTime();

--- a/src/Rules/ValidAt.php
+++ b/src/Rules/ValidAt.php
@@ -17,14 +17,14 @@ class ValidAt implements ValidationRuleInterface
     /** @var string $failure */
     protected $failure = 'OK';
 
-    /** @var \DateTime $now */
+    /** @var \DateTimeInterface $now */
     protected $now;
 
     /**
      * ValidAt constructor.
-     * @param \DateTime|null $now
+     * @param \DateTimeInterface|null $now
      */
-    public function __construct(\DateTime $now = null)
+    public function __construct(\DateTimeInterface $now = null)
     {
         if (!$now) {
             $now = new \DateTime();


### PR DESCRIPTION
Building upon the work done in https://github.com/paragonie/paseto/pull/64 this accepts `DateTimeInterface` in **all** methods that previously accepted `DateTime`, so that `DateTimeImmutable` can now be used.
None of the methods perform any manipulation on the incoming date object so this should be safe.