### PR TITLE
Builder: fix toString that return JSON array if claims is empty

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -422,7 +422,7 @@ class Builder
         $this->setKey($this->key, true);
         $this->setPurpose($this->purpose, true);
 
-        $claims = \json_encode($this->token->getClaims());
+        $claims = \json_encode($this->token->getClaims(), JSON_FORCE_OBJECT);
         $protocol = $this->version;
         ProtocolCollection::throwIfUnsupported($protocol);
         switch ($this->purpose) {


### PR DESCRIPTION
Section 6 of RFC draft v01 said that "All PASETO payloads MUST be a
JSON object [RFC8259].", but when builder->toString() called without
any claims it will store the claims as JSON array instead of object.

This commit fix the json_encode by adding parameter JSON_FORCE_OBJECT
when encoding claims on method sign().

Fix #119