### PR TITLE
Initial Draft for PASETO v3/v4 specifications

### DIFF
--- a/docs/01-Protocol-Versions/README.md
+++ b/docs/01-Protocol-Versions/README.md
@@ -11,8 +11,10 @@ to assist in cross-platform library development.
    * The nonce or initialization vector must be covered by the authentication
      tag, not just the ciphertext.
    * Some degree of nonce-misuse resistance should be provided by any future schemes. 
-2. Non-deterministic, stateful, and otherwise dangerous signature schemes (e.g. ECDSA
-   without RFC 6979, XMSS) are forbidden.
+2. Non-deterministic, stateful, and otherwise dangerous signature schemes (e.g. ~~ECDSA
+   without RFC 6979,~~ XMSS) are forbidden.
+   * ECDSA without RFC 6979 is permitted, but *only* when a CSPRNG is reliably available.
+     If this cannot be guaranteed, you **MUST NOT** implement ECDSA without RFC 6979.
 3. Public-key cryptography must be IND-CCA2 secure to be considered for inclusion.
    * This means no RSA with PKCS1v1.5 padding, textbook RSA, etc.
 4. By default, libraries should only allow the two most recent versions in a family

--- a/docs/01-Protocol-Versions/README.md
+++ b/docs/01-Protocol-Versions/README.md
@@ -30,7 +30,7 @@ to assist in cross-platform library development.
    * User-defined homemade protocols are discouraged. If implementors wish to break
      this rule and define their own custom protocol suite, they must NOT continue
      the {`v1`, `v2`, ... } series naming convention.
-   * Any version identifiers that match the regular expression, `/^v[0-9\.]+$/` are
+   * Any version identifiers that match the regular expression, `/^v[0-9\-\.]+/` are
      reserved by the PASETO development team.
 
 # Versions

--- a/docs/01-Protocol-Versions/README.md
+++ b/docs/01-Protocol-Versions/README.md
@@ -15,10 +15,15 @@ to assist in cross-platform library development.
    without RFC 6979, XMSS) are forbidden.
 3. Public-key cryptography must be IND-CCA2 secure to be considered for inclusion.
    * This means no RSA with PKCS1v1.5 padding, textbook RSA, etc.
-4. By default, libraries should only allow the two most recent versions to be used.
-   * If there are only two versions, that means `v1` and `v2`.
-   * If a future post-quantum `v3` is defined, `v1` should no longer be accepted.
-   * If an additional version `v4` is defined, `v2` should also no longer be accepted.
+4. By default, libraries should only allow the two most recent versions in a family
+   to be used.
+   * The NIST family of versions is `v1` and `v3`.
+   * The Sodium family of versions is `v2` and `v4`.
+   * If a future post-quantum `v5` (NIST) and/or `v6` (Sodium) is defined, 
+     `v1` and `v2` should no longer be accepted.
+   * This is a deviation from the **original** intent of this rule, to encapsulate
+     the fact that we have parallel versions. In the future, we expect this to converge
+     to one family of versions.
 5. New versions will be decided and formalized by the PASETO developers. 
    * User-defined homemade protocols are discouraged. If implementors wish to break
      this rule and define their own custom protocol suite, they must NOT continue
@@ -28,7 +33,7 @@ to assist in cross-platform library development.
 
 # Versions
 
-## Version 1: Compatibility Mode
+## Version 1: NIST Compatibility
 
 See [the version 1 specification](Version1.md) for details. At a glance:
 
@@ -43,7 +48,7 @@ See [the version 1 specification](Version1.md) for details. At a glance:
   * The HMAC covers the header, nonce, and ciphertext
   * Reference implementation in [Version1.php](https://github.com/paragonie/paseto/blob/master/src/Protocol/Version1.php):
     * See `aeadEncrypt()` for encryption
-    * See `aeadDncrypt()` for decryption
+    * See `aeadDecrypt()` for decryption
 * **`v1.public`**: Asymmetric Authentication (Public-Key Signatures):
   * 2048-bit RSA keys
   * RSASSA-PSS with
@@ -61,7 +66,7 @@ Version 1 is recommended only for legacy systems that cannot use modern cryptogr
 
 See also: [Common implementation details for all versions](Common.md).
 
-## Version 2: Recommended
+## Version 2: Sodium Original
 
 See [the version 2 specification](Version2.md) for details. At a glance:
 
@@ -84,3 +89,21 @@ See [the version 2 specification](Version2.md) for details. At a glance:
     * See `verify()` for signature verification
 
 See also: [Common implementation details for all versions](Common.md).
+
+## Version 3: NIST Modern
+
+* **`v3.local`**: Symmetric Authenticated Encryption:
+    * AES-256-CTR + HMAC-SHA384 (Encrypt-then-MAC)
+    * Key-splitting: HKDF-SHA384
+        * Info for encryption key: `paseto-encryption-key`
+          The encryption key and implicit counter nonce are both returned
+          from HKDF in this version.
+        * Info for authentication key: `paseto-auth-key-for-aead`
+    * 32-byte nonce (no longer prehashed), passed entirely to HKDF.
+    * The HMAC covers the header, nonce, and ciphertext
+* **`v3.public`**: Asymmetric Authentication (Public-Key Signatures):
+    * ECDSA over NIST P-384, with SHA-384,
+      using [RFC 6979 deterministic k-values](https://tools.ietf.org/html/rfc6979).
+
+## Version 4: Sodium Modern
+

--- a/docs/01-Protocol-Versions/README.md
+++ b/docs/01-Protocol-Versions/README.md
@@ -48,6 +48,7 @@ See [the version 1 specification](Version1.md) for details. At a glance:
   * The nonce calculated from HMAC-SHA384(message, `random_bytes(32)`)
     truncated to 32 bytes, during encryption only
   * The HMAC covers the header, nonce, and ciphertext
+      * It also covers the footer, if provided
   * Reference implementation in [Version1.php](https://github.com/paragonie/paseto/blob/master/src/Protocol/Version1.php):
     * See `aeadEncrypt()` for encryption
     * See `aeadDecrypt()` for decryption
@@ -94,6 +95,8 @@ See also: [Common implementation details for all versions](Common.md).
 
 ## Version 3: NIST Modern
 
+See [the version 3 specification](Version3.md) for details. At a glance:
+
 * **`v3.local`**: Symmetric Authenticated Encryption:
     * AES-256-CTR + HMAC-SHA384 (Encrypt-then-MAC)
     * Key-splitting: HKDF-SHA384
@@ -103,9 +106,30 @@ See also: [Common implementation details for all versions](Common.md).
         * Info for authentication key: `paseto-auth-key-for-aead`
     * 32-byte nonce (no longer prehashed), passed entirely to HKDF.
     * The HMAC covers the header, nonce, and ciphertext
+      * It also covers the footer, if provided
+      * It also covers the implicit assertions, if provided
 * **`v3.public`**: Asymmetric Authentication (Public-Key Signatures):
     * ECDSA over NIST P-384, with SHA-384,
-      using [RFC 6979 deterministic k-values](https://tools.ietf.org/html/rfc6979).
+      using [RFC 6979 deterministic k-values](https://tools.ietf.org/html/rfc6979)
+      (if reasonably practical; otherwise a CSPRNG **MUST** be used).
 
 ## Version 4: Sodium Modern
+
+See [the version 4 specification](Version4.md) for details. At a glance:
+
+* **`v4.local`**: Symmetric Authenticated Encryption:
+    * XChaCha20 + BLAKE2b-MAC (Encrypt-then-MAC)
+    * Key-splitting: BLAKE2b
+        * Info for encryption key: `paseto-encryption-key`
+          The encryption key and implicit counter nonce are both returned
+          from BLAKE2b in this version.
+        * Info for authentication key: `paseto-auth-key-for-aead`
+    * 32-byte nonce (no longer prehashed), passed entirely to BLAKE2b.
+    * The BLAKE2b-MAC covers the header, nonce, and ciphertext
+        * It also covers the footer, if provided
+        * It also covers the implicit assertions, if provided
+* **`v4.public`**: Asymmetric Authentication (Public-Key Signatures):
+    * Ed25519 (EdDSA over Curve25519)
+    * Signing: `sodium_crypto_sign_detached()`
+    * Verifying: `sodium_crypto_sign_verify_detached()`
 

--- a/docs/01-Protocol-Versions/Version3.md
+++ b/docs/01-Protocol-Versions/Version3.md
@@ -128,6 +128,8 @@ implicit assertion `i` (which defaults to empty string):
    (pre-authentication encoding). We'll call this `m2`.
 3. Sign `m2` using ECDSA over P-384 with deterministic nonces ([RFC 6979](https://tools.ietf.org/html/rfc6979))
    with the private key `sk`. We'll call this `sig`.
+   The output of `sig` MUST be in the format `r || s` (where `||`means concatenate),
+   for a total length of 96 bytes.
    ```
    sig = crypto_sign_ecdsa_p384(
        message = m2,

--- a/docs/01-Protocol-Versions/Version3.md
+++ b/docs/01-Protocol-Versions/Version3.md
@@ -126,10 +126,13 @@ implicit assertion `i` (which defaults to empty string):
 2. Pack `h`, `m`, `f`, and `i` together using
    [PAE](https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#authentication-padding)
    (pre-authentication encoding). We'll call this `m2`.
-3. Sign `m2` using ECDSA over P-384 with deterministic nonces ([RFC 6979](https://tools.ietf.org/html/rfc6979))
-   with the private key `sk`. We'll call this `sig`.
+3. Sign `m2` using ECDSA over P-384 with the private key `sk`. We'll call this `sig`.
    The output of `sig` MUST be in the format `r || s` (where `||`means concatenate),
    for a total length of 96 bytes.
+   Signatures **SHOULD** use deterministic nonces ([RFC 6979](https://tools.ietf.org/html/rfc6979))
+   if possible, to mitigate the risk of [k-value reuse](https://blog.trailofbits.com/2020/06/11/ecdsa-handle-with-care/).
+   If RFC 6979 is not available in your programming language, ECDSA **MUST** use a CSPRNG
+   to generate the k-value.
    ```
    sig = crypto_sign_ecdsa_p384(
        message = m2,

--- a/docs/01-Protocol-Versions/Version3.md
+++ b/docs/01-Protocol-Versions/Version3.md
@@ -15,13 +15,13 @@ implicit assertion `i` (which defaults to empty string):
    to get the nonce, `n`.
 3. Split the key into an Encryption key (`Ek`) and Authentication key (`Ak`),
    using HKDF-HMAC-SHA384, with `n` appended to the info rather than the salt.
-    * The output length **MUST** be 48 for the first key derivation and 32 for `Ak`.
+    * The output length **MUST** be 48 for both key derivations.
     * The derived key will be the leftmost 32 bytes of the first HKDF derivation.
    
    The remaining 16 bytes will be used as a counter nonce (`n2`):
    ```
    tmp = hkdf_sha384(
-       len = 48
+       len = 48,
        ikm = k,
        info = "paseto-encryption-key" || n,
        salt = NULL
@@ -29,7 +29,7 @@ implicit assertion `i` (which defaults to empty string):
    Ek = tmp[0:32]
    n2 = tmp[32:]
    Ak = hkdf_sha384(
-       len = 32
+       len = 48,
        ikm = k,
        info = "paseto-auth-key-for-aead" || n,
        salt = NULL
@@ -77,13 +77,13 @@ implicit assertion `i` (which defaults to empty string):
       **paseto-encryption-key**.
     * For authentication keys, the **info** parameter for HKDF **MUST** be set to
       **paseto-auth-key-for-aead**.
-    * The output length **MUST** be 48 for the first key derivation and 32 for `Ak`.
+    * The output length **MUST** be 48 for both key derivations.
       The leftmost 32 bytes of the first key derivation will produce `Ek`, while
       the remaining 16 bytes will be the AES nonce `n2`.
 
    ```
    tmp = hkdf_sha384(
-       len = 48
+       len = 48,
        ikm = k,
        info = "paseto-encryption-key" || n,
        salt = NULL
@@ -91,7 +91,7 @@ implicit assertion `i` (which defaults to empty string):
    Ek = tmp[0:32]
    n2 = tmp[32:]
    Ak = hkdf_sha384(
-       len = 32
+       len = 48,
        ikm = k,
        info = "paseto-auth-key-for-aead" || n,
        salt = NULL

--- a/docs/01-Protocol-Versions/Version3.md
+++ b/docs/01-Protocol-Versions/Version3.md
@@ -63,7 +63,7 @@ implicit assertion `i` (which defaults to empty string):
 1. If `f` is not empty, implementations **MAY** verify that the value appended
    to the token matches some expected string `f`, provided they do so using a
    constant-time string compare function.
-2. Verify that the message begins with `v1.local.`, otherwise throw an
+2. Verify that the message begins with `v3.local.`, otherwise throw an
    exception. This constant will be referred to as `h`.
 3. Decode the payload (`m` sans `h`, `f`, and the optional trailing period
    between `m` and `f`) from b64 to raw binary. Set:

--- a/docs/01-Protocol-Versions/Version3.md
+++ b/docs/01-Protocol-Versions/Version3.md
@@ -123,9 +123,14 @@ optional footer `f` (which defaults to empty string), and an optional
 implicit assertion `i` (which defaults to empty string):
 
 1. Set `h` to `v3.public.`
-2. Pack `h`, `m`, `f`, and `i` together using
+2. Pack `pk`, `h`, `m`, `f`, and `i` together using
    [PAE](https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#authentication-padding)
    (pre-authentication encoding). We'll call this `m2`.
+   * Note: `pk` is the public key corresponding to `sk` (which **MUST** use
+     [point compression](https://www.secg.org/sec1-v2.pdf)). `pk` **MUST** be 49
+     bytes long, and the first byte **MUST** be `0x02` or `0x03` (depending on the
+     sign of the Y coordinate). The remaining bytes **MUST** be the X coordinate,
+     using big-endian byte order.
 3. Sign `m2` using ECDSA over P-384 with the private key `sk`. We'll call this `sig`.
    The output of `sig` MUST be in the format `r || s` (where `||`means concatenate),
    for a total length of 96 bytes.
@@ -147,7 +152,8 @@ implicit assertion `i` (which defaults to empty string):
 
 ## Verify
 
-Given a signed message `sm`, ECDSA public key `pk` (which **MUST** use point compression),
+Given a signed message `sm`, ECDSA public key `pk` (which **MUST** use 
+[point compression](https://www.secg.org/sec1-v2.pdf) (Section 2.3.3)),
 and optional footer `f` (which defaults to empty string), and an optional
 implicit assertion `i` (which defaults to empty string):
 
@@ -160,9 +166,12 @@ implicit assertion `i` (which defaults to empty string):
    between `m` and `f`) from b64 to raw binary. Set:
     * `s` to the rightmost 96 bytes
     * `m` to the leftmost remainder of the payload, excluding `s`
-4. Pack `h`, `m`, `f`, and `i` together (in that order) using PAE (see
+4. Pack `pk`, `h`, `m`, `f`, and `i` together (in that order) using PAE (see
    [PAE](https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#authentication-padding).
    We'll call this `m2`.
+   * `pk` **MUST** be 49 bytes long, and the first byte **MUST** be `0x02` or `0x03`
+     (depending on the sign of the Y coordinate). The remaining bytes **MUST** be
+     the X coordinate, using big-endian byte order.
 5. Use ECDSA to verify that the signature is valid for the message:
    ```
    valid = crypto_sign_ecdsa_p384_verify(

--- a/docs/01-Protocol-Versions/Version3.md
+++ b/docs/01-Protocol-Versions/Version3.md
@@ -15,7 +15,9 @@ implicit assertion `i` (which defaults to empty string):
    to get the nonce, `n`.
 3. Split the key into an Encryption key (`Ek`) and Authentication key (`Ak`),
    using HKDF-HMAC-SHA384, with `n` as the HKDF salt.
-   The derived key will be the leftmost 32 bytes of the first HKDF derivation.
+    * The output length **MUST** be 48 for the first key derivation and 32 for `Ak`.
+    * The derived key will be the leftmost 32 bytes of the first HKDF derivation.
+   
    The remaining 16 bytes will be used as a counter nonce (`n2`):
    ```
    tmp = hkdf_sha384(
@@ -66,7 +68,7 @@ implicit assertion `i` (which defaults to empty string):
 2. Verify that the message begins with `v3.local.`, otherwise throw an
    exception. This constant will be referred to as `h`.
 3. Decode the payload (`m` sans `h`, `f`, and the optional trailing period
-   between `m` and `f`) from b64 to raw binary. Set:
+   between `m` and `f`) from base64url to raw binary. Set:
     * `n` to the leftmost 32 bytes
     * `t` to the rightmost 48 bytes
     * `c` to the middle remainder of the payload, excluding `n` and `t`
@@ -183,7 +185,7 @@ implicit assertion `i` (which defaults to empty string):
 2. Verify that the message begins with `v3.public.`, otherwise throw an
    exception. This constant will be referred to as `h`.
 3. Decode the payload (`sm` sans `h`, `f`, and the optional trailing period
-   between `m` and `f`) from b64 to raw binary. Set:
+   between `m` and `f`) from base64url to raw binary. Set:
     * `s` to the rightmost 96 bytes
     * `m` to the leftmost remainder of the payload, excluding `s`
 4. Pack `pk`, `h`, `m`, `f`, and `i` together (in that order) using PAE (see

--- a/docs/01-Protocol-Versions/Version3.md
+++ b/docs/01-Protocol-Versions/Version3.md
@@ -1,0 +1,169 @@
+# Paseto Version 3
+
+## GetNonce
+
+Throw an exception. We don't do this in version 3.
+
+## Encrypt
+
+Given a message `m`, key `k`, and optional footer `f`
+(which defaults to empty string), and an optional
+implicit assertion `i` (which defaults to empty string):
+
+1. Set header `h` to `v3.local.`
+2. Generate 32 random bytes from the OS's CSPRNG
+   to get the nonce, `n`.
+3. Split the key into an Encryption key (`Ek`) and Authentication key (`Ak`),
+   using HKDF-HMAC-SHA384, with `n` as the HKDF salt.
+   The derived key will be the leftmost 32 bytes of the first HKDF derivation.
+   The remaining 16 bytes will be used as a counter nonce (`n2`):
+   ```
+   tmp = hkdf_sha384(
+       len = 48
+       ikm = k,
+       info = "paseto-encryption-key",
+       salt = n
+   );
+   Ek = tmp[0:32]
+   n2 = tmp[32:]
+   Ak = hkdf_sha384(
+       len = 32
+       ikm = k,
+       info = "paseto-auth-key-for-aead",
+       salt = n
+   );
+   ```
+5. Encrypt the message using `AES-256-CTR`, using `Ek` as the key and
+   `n2` as the nonce. We'll call this `c`:
+   ```
+   c = aes256ctr_encrypt(
+       plaintext = m,
+       nonce = n2
+       key = Ek
+   );
+   ```
+6. Pack `h`, `n`, `c`, `f`, and `i` together using
+   [PAE](https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#authentication-padding)
+   (pre-authentication encoding). We'll call this `preAuth`
+7. Calculate HMAC-SHA384 of the output of `preAuth`, using `Ak` as the
+   authentication key. We'll call this `t`.
+8. If `f` is:
+    * Empty: return "`h` || base64url(`n` || `c` || `t`)"
+    * Non-empty: return "`h` || base64url(`n` || `c` || `t`) || `.` || base64url(`f`)"
+    * ...where || means "concatenate"
+    * Note: `base64url()` means Base64url from RFC 4648 without `=` padding.
+
+## Decrypt
+
+Given a message `m`, key `k`, and optional footer `f`
+(which defaults to empty string), and an optional
+implicit assertion `i` (which defaults to empty string):
+
+
+1. If `f` is not empty, implementations **MAY** verify that the value appended
+   to the token matches some expected string `f`, provided they do so using a
+   constant-time string compare function.
+2. Verify that the message begins with `v1.local.`, otherwise throw an
+   exception. This constant will be referred to as `h`.
+3. Decode the payload (`m` sans `h`, `f`, and the optional trailing period
+   between `m` and `f`) from b64 to raw binary. Set:
+    * `n` to the leftmost 32 bytes
+    * `t` to the rightmost 48 bytes
+    * `c` to the middle remainder of the payload, excluding `n` and `t`
+4. Split the key (`k`) into an Encryption key (`Ek`) and an Authentication key
+   (`Ak`), `n` as the HKDF salt.
+    * For encryption keys, the **info** parameter for HKDF **MUST** be set to
+      **paseto-encryption-key**.
+    * For authentication keys, the **info** parameter for HKDF **MUST** be set to
+      **paseto-auth-key-for-aead**.
+    * The output length **MUST** be 48 for the first key derivation and 32 for `Ak`.
+      The leftmost 32 bytes of the first key derivation will produce `Ek`, while
+      the remaining 16 bytes will be the AES nonce `n2`.
+
+   ```
+   tmp = hkdf_sha384(
+       len = 48
+       ikm = k,
+       info = "paseto-encryption-key",
+       salt = n
+   );
+   Ek = tmp[0:32]
+   n2 = tmp[32:]
+   Ak = hkdf_sha384(
+       len = 32
+       ikm = k,
+       info = "paseto-auth-key-for-aead",
+       salt = n
+   );
+   ```
+5. Pack `h`, `n`, `c`, `f`, and `i` together (in that order) using
+   [PAE](https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#authentication-padding).
+   We'll call this `preAuth`.
+6. Recalculate HMAC-SHA-384 of `preAuth` using `Ak` as the key. We'll call this
+   `t2`.
+7. Compare `t` with `t2` using a constant-time string compare function. If they
+   are not identical, throw an exception.
+   * You **MUST** use a constant-time string compare function to be compliant.
+     If you do not have one available to you in your programming language/framework,
+     you MUST use [Double HMAC](https://paragonie.com/blog/2015/11/preventing-timing-attacks-on-string-comparison-with-double-hmac-strategy).
+8. Decrypt `c` using `AES-256-CTR`, using `Ek` as the key and `n2` as the nonce,
+   then return the plaintext.
+   ```
+   return aes256ctr_decrypt(
+       cipherext = c,
+       nonce = n2
+       key = Ek
+   );
+   ```
+
+## Sign
+
+Given a message `m`, 384-bit ECDSA secret key `sk`, and
+optional footer `f` (which defaults to empty string), and an optional
+implicit assertion `i` (which defaults to empty string):
+
+1. Set `h` to `v3.public.`
+2. Pack `h`, `m`, `f`, and `i` together using
+   [PAE](https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#authentication-padding)
+   (pre-authentication encoding). We'll call this `m2`.
+3. Sign `m2` using ECDSA over P-384 with deterministic nonces ([RFC 6979](https://tools.ietf.org/html/rfc6979))
+   with the private key `sk`. We'll call this `sig`.
+   ```
+   sig = crypto_sign_ecdsa_p384(
+       message = m2,
+       private_key = sk
+   );
+   ```
+4. If `f` is:
+    * Empty: return "`h` || base64url(`m` || `sig`)"
+    * Non-empty: return "`h` || base64url(`m` || `sig`) || `.` || base64url(`f`)"
+    * ...where || means "concatenate"
+    * Note: `base64url()` means Base64url from RFC 4648 without `=` padding.
+
+## Verify
+
+Given a signed message `sm`, ECDSA public key `pk` (which **MUST** use point compression),
+and optional footer `f` (which defaults to empty string), and an optional
+implicit assertion `i` (which defaults to empty string):
+
+1. If `f` is not empty, implementations **MAY** verify that the value appended
+   to the token matches some expected string `f`, provided they do so using a
+   constant-time string compare function.
+2. Verify that the message begins with `v3.public.`, otherwise throw an
+   exception. This constant will be referred to as `h`.
+3. Decode the payload (`sm` sans `h`, `f`, and the optional trailing period
+   between `m` and `f`) from b64 to raw binary. Set:
+    * `s` to the rightmost 96 bytes
+    * `m` to the leftmost remainder of the payload, excluding `s`
+4. Pack `h`, `m`, `f`, and `i` together (in that order) using PAE (see
+   [PAE](https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#authentication-padding).
+   We'll call this `m2`.
+5. Use RSA to verify that the signature is valid for the message:
+   ```
+   valid = crypto_sign_ecdsa_p384_verify(
+       signature = s,
+       message = m2,
+       public_key = pk
+   );
+   ```
+6. If the signature is valid, return `m`. Otherwise, throw an exception.

--- a/docs/01-Protocol-Versions/Version3.md
+++ b/docs/01-Protocol-Versions/Version3.md
@@ -163,7 +163,7 @@ implicit assertion `i` (which defaults to empty string):
 4. Pack `h`, `m`, `f`, and `i` together (in that order) using PAE (see
    [PAE](https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#authentication-padding).
    We'll call this `m2`.
-5. Use RSA to verify that the signature is valid for the message:
+5. Use ECDSA to verify that the signature is valid for the message:
    ```
    valid = crypto_sign_ecdsa_p384_verify(
        signature = s,

--- a/docs/01-Protocol-Versions/Version4.md
+++ b/docs/01-Protocol-Versions/Version4.md
@@ -1,0 +1,165 @@
+# Paseto Version 2
+
+## Encrypt
+
+Given a message `m`, key `k`, and optional footer `f`, and an optional
+implicit assertion `i` (which defaults to empty string).
+
+1. Set header `h` to `v4.local.`
+2. Generate 32 random bytes from the OS's CSPRNG, `n`.
+3. Split the key into an Encryption key (`Ek`) and Authentication key (`Ak`),
+   using keyed BLAKE2b, using the domain separation constants and `n` as the
+   message, and the input key as the key. The first value will be 56 bytes,
+   the second will be 32 bytes.
+   The derived key will be the leftmost 32 bytes of the hash output.
+   The remaining 24 bytes will be used as a counter nonce (`n2`):
+   ```
+   tmp = crypto_generichash(
+       msg = "paseto-encryption-key" || n,
+       key = key,
+       length = 56
+   );
+   Ek = tmp[0:32]
+   n2 = tmp[32:]
+   Ak = crypto_generichash(
+       msg = "paseto-auth-key-for-aead" || n,
+       key = key,
+       length = 32
+   );
+   ```
+4. Encrypt the message using XChaCha20, using `n2` from step 3 as the nonce.
+   ```
+   c = crypto_stream_xchacha20_xor(
+       message = m
+       nonce = n2
+       key = k
+   );
+   ```
+5. Pack `h`, `n`, `c`, `f`, and `i` together (in that order) using
+   [PAE](https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#authentication-padding).
+   We'll call this `preAuth`.
+6. Calculate BLAKE2b-MAC of the output of `preAuth`, using `Ak` as the
+   authentication key. We'll call this `t`.
+   ```
+   t = crypto_generichash(
+       message = preAuth
+       key = Ak,
+       length = 32
+   );
+   ```
+7. If `f` is:
+    * Empty: return h || b64(n || c)
+    * Non-empty: return h || b64(n || c) || `.` || base64url(f)
+    * ...where || means "concatenate"
+
+## Decrypt
+
+Given a message `m`, key `k`, and optional footer `f`, and an optional
+implicit assertion `i` (which defaults to empty string).
+
+1. If `f` is not empty, implementations **MAY** verify that the value appended
+   to the token matches some expected string `f`, provided they do so using a
+   constant-time string compare function.
+2. Verify that the message begins with `v4.local.`, otherwise throw an
+   exception. This constant will be referred to as `h`.
+3. Decode the payload (`m` sans `h`, `f`, and the optional trailing period
+   between `m` and `f`) from base64url to raw binary. Set:
+    * `n` to the leftmost 32 bytes
+    * `c` to the middle remainder of the payload, excluding `n`.
+4. Split the key into an Encryption key (`Ek`) and Authentication key (`Ak`),
+   using keyed BLAKE2b, using the domain separation constants and `n` as the
+   message, and the input key as the key. The first value will be 56 bytes,
+   the second will be 32 bytes.
+   The derived key will be the leftmost 32 bytes of the hash output.
+   The remaining 24 bytes will be used as a counter nonce (`n2`):
+   ```
+   tmp = crypto_generichash(
+       msg = "paseto-encryption-key" || n,
+       key = key,
+       length = 56
+   );
+   Ek = tmp[0:32]
+   n2 = tmp[32:]
+   Ak = crypto_generichash(
+       msg = "paseto-auth-key-for-aead" || n,
+       key = key,
+       length = 32
+   );
+   ```
+4. Pack `h`, `n`, `c`, `f`, and `i` together (in that order) using
+   [PAE](https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#authentication-padding).
+   We'll call this `preAuth`.
+5. Re-calculate BLAKE2b-MAC of the output of `preAuth`, using `Ak` as the
+   authentication key. We'll call this `t2`.
+   ```
+   t2 = crypto_generichash(
+       message = preAuth
+       key = Ak,
+       length = 32
+   );
+   ```
+6. Compare `t` with `t2` using a constant-time string compare function. If they
+   are not identical, throw an exception.
+    * You **MUST** use a constant-time string compare function to be compliant.
+      If you do not have one available to you in your programming language/framework,
+      you MUST use [Double HMAC](https://paragonie.com/blog/2015/11/preventing-timing-attacks-on-string-comparison-with-double-hmac-strategy).
+7. Decrypt `c` using `XChaCha20`, store the result in `p`.
+   ```
+   p = crypto_stream_xchacha20_xor(
+      ciphertext = c
+      nonce = n2
+      key = k
+   );
+   ```
+8. If decryption failed, throw an exception. Otherwise, return `p`.
+
+## Sign
+
+Given a message `m`, Ed25519 secret key `sk`, and
+optional footer `f` (which defaults to empty string), and an optional
+implicit assertion `i` (which defaults to empty string):
+
+1. Set `h` to `v4.public.`
+2. Pack `h`, `m`, `f`, and `i` together using
+   [PAE](https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#authentication-padding)
+   (pre-authentication encoding). We'll call this `m2`.
+3. Sign `m2` using Ed25519 `sk`. We'll call this `sig`.
+   ```
+   sig = crypto_sign_detached(
+       message = m2,
+       private_key = sk
+   );
+   ```
+4. If `f` is:
+    * Empty: return "`h` || base64url(`m` || `sig`)"
+    * Non-empty: return "`h` || base64url(`m` || `sig`) || `.` || base64url(`f`)"
+    * ...where || means "concatenate"
+    * Note: `base64url()` means Base64url from RFC 4648 without `=` padding.
+
+## Verify
+
+Given a signed message `sm`, public key `pk`, and optional footer `f`
+(which defaults to empty string), and an optional
+implicit assertion `i` (which defaults to empty string):
+
+1. If `f` is not empty, implementations **MAY** verify that the value appended
+   to the token matches some expected string `f`, provided they do so using a
+   constant-time string compare function.
+2. Verify that the message begins with `v4.public.`, otherwise throw an exception.
+   This constant will be referred to as `h`.
+3. Decode the payload (`sm` sans `h`, `f`, and the optional trailing period
+   between `m` and `f`) from base64url to raw binary. Set:
+    * `s` to the rightmost 64 bytes
+    * `m` to the leftmost remainder of the payload, excluding `s`
+4. Pack `h`, `m`, `f`, `i` together using
+   [PAE](https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#authentication-padding).
+   We'll call this `m2`.
+5. Use Ed25519 to verify that the signature is valid for the message:
+   ```
+   valid = crypto_sign_verify_detached(
+       signature = s,
+       message = m2,
+       public_key = pk
+   );
+   ```
+6. If the signature is valid, return `m`. Otherwise, throw an exception.

--- a/docs/01-Protocol-Versions/Version4.md
+++ b/docs/01-Protocol-Versions/Version4.md
@@ -1,4 +1,4 @@
-# Paseto Version 2
+# Paseto Version 4
 
 ## Encrypt
 

--- a/docs/01-Protocol-Versions/Version4.md
+++ b/docs/01-Protocol-Versions/Version4.md
@@ -48,8 +48,8 @@ implicit assertion `i` (which defaults to empty string).
    );
    ```
 7. If `f` is:
-    * Empty: return h || b64(n || c)
-    * Non-empty: return h || b64(n || c) || `.` || base64url(f)
+    * Empty: return h || base64url(n || c)
+    * Non-empty: return h || base64url(n || c) || `.` || base64url(f)
     * ...where || means "concatenate"
 
 ## Decrypt

--- a/docs/01-Protocol-Versions/Version4.md
+++ b/docs/01-Protocol-Versions/Version4.md
@@ -62,6 +62,9 @@ implicit assertion `i` (which defaults to empty string).
    constant-time string compare function.
 2. Verify that the message begins with `v4.local.`, otherwise throw an
    exception. This constant will be referred to as `h`.
+   * **Future-proofing**: If a future PASETO variant allows for encodings other
+     than JSON (e.g., CBOR), future implementations **MAY** also permit those 
+     values at this step (e.g. `v4c.local.`).
 3. Decode the payload (`m` sans `h`, `f`, and the optional trailing period
    between `m` and `f`) from base64url to raw binary. Set:
     * `n` to the leftmost 32 bytes

--- a/docs/03-Implementation-Guide/01-Payload-Processing.md
+++ b/docs/03-Implementation-Guide/01-Payload-Processing.md
@@ -109,8 +109,9 @@ function getJsonDepth(data: string): number {
     let depth = 1;
     
     // Step 6
-    while (stripped.length > 0 && stripped !== previous) { 
-        stripped.split(/(\{\}|\[\])/g).join('');
+    while (stripped.length > 0 && stripped !== previous) {
+        previous = stripped;
+        stripped = stripped.replace(/({}|\[\])/g, '');
         depth++;
     }
     

--- a/docs/03-Implementation-Guide/01-Payload-Processing.md
+++ b/docs/03-Implementation-Guide/01-Payload-Processing.md
@@ -70,7 +70,8 @@ upper limit, so you're forced to take matters into your own hands.
 A simple way of enforcing the maximum depth of a JSON string without having
 to parse it with your JSON library is to employ the following algorithm:
 
-1. Create a copy of the JSON string with all `\"` sequences removed.
+1. Create a copy of the JSON string with all `\"` sequences and whitespace
+   characters removed.
    This will prevent weird edge cases in step 2.
 2. Use a regular expression to remove all quoted strings and their contents.
    For example, replacing `/"[^"]+?"([:,\}\]])/` with the first match will 
@@ -91,13 +92,13 @@ An example of this logic implemented in TypeScript is below:
 ```typescript
 function getJsonDepth(data: string): number {
     // Step 1
-    let stripped = data.replace(/\\"/, '');
+    let stripped = data.replace(/\\"/g, '').replace(/\s+/g, '');
     
     // Step 2
-    stripped = stripped.replace(/"[^"]+"([:,\}\]])/, '$1');
+    stripped = stripped.replace(/"[^"]+"([:,\}\]])/g, '$1');
     
     // Step 3
-    stripped = stripped.replace(/[^\[\{\}\]]/, '');
+    stripped = stripped.replace(/[^\[\{\}\]]/g, '');
     
     // Step 4
     if (stripped.length === 0) {
@@ -109,7 +110,7 @@ function getJsonDepth(data: string): number {
     
     // Step 6
     while (stripped.length > 0 && stripped !== previous) { 
-        stripped.split(/(\{\}|\[\])/).join('');
+        stripped.split(/(\{\}|\[\])/g).join('');
         depth++;
     }
     

--- a/docs/03-Implementation-Guide/01-Payload-Processing.md
+++ b/docs/03-Implementation-Guide/01-Payload-Processing.md
@@ -34,6 +34,31 @@ It **MUST NOT** be possible for a user to take a known public key (used by
 *public* tokens), and generate a *local* token with the same key that any PASETO
 implementations will accept.
 
+## Optional Footer
+
+PASETO places no restrictions on the contents of the authenticated footer.
+The footer's contents **MAY** be JSON-encoded (as is the payload), but it
+doesn't have to be.
+
+The footer contents is intended to be free-form and application-specific.
+
+### Storing JSON in the Footer
+
+Implementations that allow users to store JSON-encoded objects in the footer
+**MUST** give users some mechanism to validate the footer before decoding.
+
+Some example parser rules include:
+
+1. Enforcing a maximum length of the JSON-encoded string.
+2. Enforcing a maximum depth of the decoded JSON object.
+   (Recommended default: Only 1-dimensional objects.)
+
+The motivation for these additional rules is to mitigate the following
+security risks:
+
+1. Stack overflows in JSON parsers caused by too much recursion.
+2. Denial-of-Service attacks enabled by hash-table collisions.
+
 ## Registered Claims
 
 The following keys are reserved for use within PASETO. Users SHOULD NOT write

--- a/docs/03-Implementation-Guide/01-Payload-Processing.md
+++ b/docs/03-Implementation-Guide/01-Payload-Processing.md
@@ -70,6 +70,11 @@ For example, if you set the footer to `{"kid":"gandalf0"}`, you can read it with
 needing to first decrypt the token (which would in turn knowing which key to use to
 decrypt the token).
 
+[PASERK](https://github.com/paseto-standard/paserk), a PASETO extension, defines a
+universal and unambiguous way to calculate key identifiers for a PASETO key. See
+[the specification for PASERK's `ID` operation](https://github.com/paseto-standard/paserk/blob/master/operations/ID.md)
+for more information. PASERK is the **RECOMMENDED** way to serialize Key IDs.
+
 Implementations should feel free to provide a means to extract the footer from a token,
 before decryption, since the footer is used in the calculation of the authentication
 tag for the encrypted payload.

--- a/docs/03-Implementation-Guide/02-Validators.md
+++ b/docs/03-Implementation-Guide/02-Validators.md
@@ -26,4 +26,4 @@ Some examples of validation rules that libraries may wish to provide include:
 
 Example implementations of these validators are included in the PHP implementation.
 
-Validation should fail-closed by default (e.g. if invalid data is provided).
+Validation should fail-closed by default (e.g., if invalid data is provided).

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,8 @@ is used in calculating the authentication tag for the payload. It's always base6
    [our standard format](https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#authentication-padding).
 
 Thus, if you want unencrypted, but authenticated, tokens, you can simply set your payload
-to an empty string and your footer to the message you want to authenticate.
+to an empty string and your footer to the message you want to authenticate, and use a
+local token.
 
 Conversely, if you want to support key rotation, you can use the unencrypted footer to store
 the Key-ID.
@@ -59,9 +60,7 @@ so-called "algorithm agility" in favor of pre-negotiated protocols with
 version identifiers.
 
 For `local` tokens, we encrypt them exclusively using authenticated encryption
-with additional data (AEAD) modes that are also nonce-misuse resistant (NMR).
-This means even if implementations fail to use a secure random number generator
-for the large nonces, message confidentiality isn't imperiled.
+with additional data (AEAD) modes.
 
 ### 2. Usability
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,14 +18,34 @@ The `version` is a string that represents the current version of the protocol. C
 two versions are specified, which each possess their own ciphersuites. Accepted values:
 `v1`, `v2`, `v3`, `v4`.
 
+PASETO serializes its payload as a JSON string. Future documents **MAY** specify using 
+PASETO with non-JSON encoding. When this happens, a suffix will be appended to the version tag
+when a non-JSON encoding rule is used.
+
+> For example, a future PASETO-CBOR proposal might define its versions as `v1c`, `v2c`, `v3c`,
+> and `v4c`. The underlying cryptography will be the same as `v1`, `v2`, `v3`, and `v4`
+> respectively. Keys **SHOULD** be portable across different underlying encodings, but tokens
+> **MUST NOT** be transmutable between encodings without access to the symmetric key (`local` tokens)
+> or secret key (`public` tokens).
+
 The `purpose` is a short string describing the purpose of the token. Accepted values:
 `local`, `public`.
 
 * `local`: shared-key authenticated encryption
 * `public`: public-key digital signatures; **not encrypted**
 
-Any optional data can be appended to the end. This information is NOT encrypted, but it
-is used in calculating the authentication tag for the payload. It's always base64url-encoded.
+#### Versions 3 and 4
+
+In versions 3 and 4, if the `footer` is non-empty, it **MUST** be valid JSON string.
+
+If you wish to use Versions 3 or 4 with arbitrary data, it **MUST** be serialized into
+a JSON string and its value **SHOULD** be base64url-encoded.
+
+#### Versions 1 and 2
+
+In versions 1 and 2, any optional data can be appended to the end. 
+This information is NOT encrypted, but it is used in calculating the authentication tag
+for the payload. It's always base64url-encoded.
 
  * For local tokens, it's included in the associated data alongside the nonce.
  * For public tokens, it's appended to the message during the actual
@@ -33,11 +53,22 @@ is used in calculating the authentication tag for the payload. It's always base6
    [our standard format](https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#authentication-padding).
 
 Thus, if you want unencrypted, but authenticated, tokens, you can simply set your payload
-to an empty string and your footer to the message you want to authenticate, and use a
+to an empty string, then your footer to the message you want to authenticate, and use a
 local token.
 
 Conversely, if you want to support key rotation, you can use the unencrypted footer to store
 the Key-ID.
+
+If you want public-key encryption, check out [PASERK](https://github.com/paseto-standard/paserk).
+
+### Implicit Assertions
+
+PASETO `v3` and `v4` tokens support a feature called **implicit assertions**, which are used
+in the calculation of the MAC (`local` tokens) or digital signature (`public` tokens), but
+**NOT** stored in the token. (Thus, its implicitness.)
+
+An implicit assertion MUST be provided by the caller explicitly when validating a PASETO token
+if it was provided at the time of creation.
 
 ## Versions and their Respective Purposes
 
@@ -94,3 +125,13 @@ Some example use-cases:
      user authentication across multiple browsing sessions.
 2. (`public`): Transparent claims provided by a third party.
    * e.g. Authentication and authorization protocols (OAuth 2, OIDC).
+
+## Does PASETO Guarantee the Order of Keys in Its Payload?
+
+**No.** Consistently guaranteeing a given order to a deserialized JSON string is
+nontrivial across programming languages. You should not rely on this ordering behavior
+when using PASETO.
+
+Although ordering is not guaranteed, the contents will be cryptographically verified,
+and the thing that gets authenticated is a JSON string, not a deserialized object, so
+this non-guarantee will not affect the security of the token.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ version.purpose.payload.footer
 
 The `version` is a string that represents the current version of the protocol. Currently,
 two versions are specified, which each possess their own ciphersuites. Accepted values:
-`v1`, `v2`.
+`v1`, `v2`, `v3`, `v4`.
 
 The `purpose` is a short string describing the purpose of the token. Accepted values:
 `local`, `public`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,18 +34,8 @@ The `purpose` is a short string describing the purpose of the token. Accepted va
 * `local`: shared-key authenticated encryption
 * `public`: public-key digital signatures; **not encrypted**
 
-#### Versions 3 and 4
-
-In versions 3 and 4, if the `footer` is non-empty, it **MUST** be valid JSON string.
-
-If you wish to use Versions 3 or 4 with arbitrary data, it **MUST** be serialized into
-a JSON string and its value **SHOULD** be base64url-encoded.
-
-#### Versions 1 and 2
-
-In versions 1 and 2, any optional data can be appended to the end. 
-This information is NOT encrypted, but it is used in calculating the authentication tag
-for the payload. It's always base64url-encoded.
+Any optional data can be appended to the end. This information is NOT encrypted, but it is
+used in calculating the authentication tag for the payload. It's always base64url-encoded.
 
  * For local tokens, it's included in the associated data alongside the nonce.
  * For public tokens, it's appended to the message during the actual

--- a/docs/Rationale-V3-V4.md
+++ b/docs/Rationale-V3-V4.md
@@ -158,17 +158,25 @@ half was used as an AES-CTR nonce. This is tricky to analyze and didn't extend
 well for the v4.local proposal.
 
 For the sake of consistency and easy-to-analyze security designs, in both v3.local
-and v4.local, we now use the entire 32-byte salt in the HKDF step. The nonce
-used by AES-256-CTR and XChaCha20 will be derived from the HKDF output (which
-is now 48 bytes for v3.local and 56 bytes for v4.local). The first 32 bytes of
-each HKDF output will be used as the key. The remaining bytes will be used as
-the nonce for the underlying cipher.
+and v4.local, we now use the entire 32-byte random value in the HKDF step.
+
+Instead of being used as a salt, however, it will be appended to the info tag.
+This subtle change allows us to use the 
+[standard security definition for HKDF](https://eprint.iacr.org/2010/264)
+in arguments for PASETO's security, rather than treating it as just a
+pseudo-random function (PRF). This security definition requires only one salt
+to be used, but for many contexts (info tags).
+
+The nonce used by AES-256-CTR and XChaCha20 will be derived from the HKDF output
+(which is now 48 bytes for v3.local and 56 bytes for v4.local). The first 32
+bytes of each HKDF output will be used as the key. The remaining bytes will be 
+used as the nonce for the underlying cipher.
 
 Local PASETOs in v3 and v4 will always have a predictable storage size, and the
 security of these constructions is more obvious:
 
-* The probability space for either mode is 256-bits of salt + 256-bits of key,
-  for a total of 512 bits.
+* The probability space for either mode is 256-bits of randomness + 256-bits of
+  key, for a total of 512 bits.
     * The HKDF output in v3.local is 384 bits.
     * The HKDF output in v4.local is 448 bits.
     * Neither of these output sizes reduces the security against collisions.

--- a/docs/Rationale-V3-V4.md
+++ b/docs/Rationale-V3-V4.md
@@ -204,6 +204,26 @@ forcing function so that all PASETO implementations support compressed points
 since Ed25519 already includes public key with the hash function when signing
 messages. Therefore, we can safely omit this extra step in `v4.public` tokens.
 
+## Miscellaneous Changes
+
+### Define Mechanism for Extending PASETO for non-JSON Encodings
+
+PASETO serializes its payload as a JSON string. Future documents **MAY** specify using
+PASETO with non-JSON encoding. When this happens, a suffix will be appended to the version tag
+when a non-JSON encoding rule is used.
+
+> For example, a future PASETO-CBOR proposal might define its versions as `v1c`, `v2c`, `v3c`,
+> and `v4c`. The underlying cryptography will be the same as `v1`, `v2`, `v3`, and `v4`
+> respectively. Keys **SHOULD** be portable across different underlying encodings, but tokens
+> **MUST NOT** be transmutable between encodings without access to the symmetric key (`local` tokens)
+> or secret key (`public` tokens).
+
+### Consistent Rules for Footer Parsing
+
+In versions 3 and 4, if a footer is provided, it **MUST** decode to a valid JSON
+string. This ensures that footer processing is consistent across
+PASETO implementations.
+
 ## Questions and Answers
 
 ### Why Not AES-GCM in `v3.local`?

--- a/docs/Rationale-V3-V4.md
+++ b/docs/Rationale-V3-V4.md
@@ -1,0 +1,89 @@
+# Rationale for V3/V4
+
+This document aims to capture the rationale for specifying new modes
+(v3 to succeed v1, v4 to succeed v2) for PASETO.
+
+## Primary Motivations for New Versions
+
+### v4.local
+
+v2.local was originally specified to use XChaCha20-Poly1305, a boring
+AEAD mode that's obviously secure. However, we've since learned about
+key- and message-commitment, which is an important security property 
+in systems with multiple possible symmetric keys.
+
+Since PASETO added footers to support key-ids and key rotation
+strategies, this means we MUST take attacks that depend on 
+[random-key robustness](https://eprint.iacr.org/2020/1491) seriously.
+
+PASETO v4.local uses XChaCha20 to encrypt the message, but then uses
+a keyed BLAKE2b hash (which acts as HMAC) for the authentication tag.
+
+### v3.public
+
+We specified RSA for PASETO v1.public tokens, under the assumption that
+applications that must ONLY support NIST algorithms (e.g. because they
+MUST only use FIPS 140-2 validated modules to maintain compliance) would
+be adequately served by RSA signatures.
+
+To better meet the needs of applications that are NIST-dependent, PASETO
+v3.public tokens will support ECDSA over NIST's P-384 curve, with SHA-384,
+and RFC 6979 deterministic signatures.
+
+### v3.local / v4.public
+
+No specific changes were needed from (v1.local, v2.public) respectively.
+See below for some broader changes.
+
+## Beneficial Changes to V3/V4
+
+### No More Nonce-Hashing (Change)
+
+The initial motivation for hashing the random nonce with the message was
+to create an SIV-like construction to mitigate the consequences of weak
+random number generators, such as OpenSSL's (which isn't fork-safe).
+
+However, this creates an unfortunate failure mode: If your RNG fails,
+the resultant nonce is a hash of your message, which can be used to
+perform offline attacks on the plaintext.
+
+To avoid this failure mode, neither v3.local nor v4.local will pre-hash 
+the message and random value to derive a nonce. Instead, it will trust
+the CSPRNG to be secure.
+
+### Implicit Assertions (Feature)
+
+PASETO v3 and v4 tokens will support optional additional authenticated
+data that **IS NOT** stored in the token, but **IS USED** to calculate the
+authentication tag (local) or signature (public).
+
+These are called **implicit assertions**. These can be any application-specific
+data that must be provided when validating tokens, but isn't appropriate to
+store in the token itself (e.g. sensitive internal values).
+
+One example where implicit assertions might be desirable is ensuring that a PASETO
+is only used by a specific user in a multi-tenant system. Simply providing the
+user's account ID when minting and consuming PASETOs will bind the token to the
+desired context.
+
+### Better Use of HKDF Salts (Change)
+
+With v1.local, half of the 32-byte random value was used as an HKDF salt and
+half was used as an AES-CTR nonce. This is tricky to analyze and didn't extend
+well for the v4.local proposal.
+
+For the sake of consistency and easy-to-analyze security designs, in both v3.local
+and v4.local, we now use the entire 32-byte salt in the HKDF step. The nonce
+used by AES-256-CTR and XChaCha20 will be derived from the HKDF output (which
+is now 48 bytes for v3.local and 56 bytes for v4.local).
+
+Local PASETOs in v3 and v4 will always have a predictable storage size, and the
+security of these constructions is more obvious:
+
+* The probability space for either mode is 256-bits of salt + 256-bits of key,
+  for a total of 512 bits.
+  * The HKDF output in v3.local is 384 bits.
+  * The HKDF output in v4.local is 448 bits.
+  * Neither of these output sizes reduces the security against collisions.
+* A single key can be used for 2^112 PASETOs before rotation is necessary.
+* The actual nonce passed to AES-CTR and XChaCha is not revealed publicly.

--- a/docs/Rationale-V3-V4.md
+++ b/docs/Rationale-V3-V4.md
@@ -90,3 +90,22 @@ security of these constructions is more obvious:
   * Neither of these output sizes reduces the security against collisions.
 * A single key can be used for 2^112 PASETOs before rotation is necessary.
 * The actual nonce passed to AES-CTR and XChaCha is not revealed publicly.
+
+### V3 Signatures Prove Exclusive Ownership (Enhancement)
+
+RSA and ECDSA signatures [do not prove Exclusive Ownership](http://www.bolet.org/~pornin/2005-acns-pornin+stern.pdf).
+This is almost never a problem for most protocols, unless you *expect* this property
+to hold when it doesn't.
+
+Section 3.3 of the paper linked above describes how to achieve Universal Exclusive
+Ownership (UEO) without increasing the signature size: Always include the public
+key in the message that's being signed.
+
+Consequently, `v3.public` PASETOs will include the raw bytes of the public
+key in the PAE step for calculating signatures. The public key is always a
+compressed point (`0x02` or `0x03`, followed by the X coordinate, for a total
+of 49 bytes).
+
+[Ed25519, by design, does not suffer from this](https://eprint.iacr.org/2020/823),
+since Ed25519 already includes public key with the hash function when signing
+messages. Therefore, we can safely omit this extra step in `v4.local` tokens.

--- a/docs/Rationale-V3-V4.md
+++ b/docs/Rationale-V3-V4.md
@@ -28,7 +28,8 @@ be adequately served by RSA signatures.
 
 To better meet the needs of applications that are NIST-dependent, PASETO
 v3.public tokens will support ECDSA over NIST's P-384 curve, with SHA-384,
-and RFC 6979 deterministic signatures.
+and (preferably) using RFC 6979 deterministic signatures. (RFC 6979 is a
+**SHOULD**, not a **MUST**, due to library availability issues.)
 
 ### v3.local / v4.public
 

--- a/docs/Rationale-V3-V4.md
+++ b/docs/Rationale-V3-V4.md
@@ -9,11 +9,11 @@ This document aims to capture the rationale for specifying new modes
 
 v2.local was originally specified to use XChaCha20-Poly1305, a boring
 AEAD mode that's obviously secure. However, we've since learned about
-key- and message-commitment, which is an important security property 
+key- and message-commitment, which is an important security property
 in systems with multiple possible symmetric keys.
 
 Since PASETO added footers to support key-ids and key rotation
-strategies, this means we MUST take attacks that depend on 
+strategies, this means we MUST take attacks that depend on
 [random-key robustness](https://eprint.iacr.org/2020/1491) seriously.
 
 PASETO v4.local uses XChaCha20 to encrypt the message, but then uses
@@ -44,33 +44,33 @@ ECDSA is much more dangerous to implement than Ed25519:
    to ensure this, attackers can determine your secret key through
    [lattice attacks](https://eprint.iacr.org/2019/023).
 3. The computing `k^-1 (mod p)` must be constant-time to avoid leaking `k`.
-   * Most bignum libraries **DO NOT** provide a constant-time modular 
-     inverse function, but cryptography libraries often do. This is something
-     a security auditor will need to verify for each implementation.
+    * Most bignum libraries **DO NOT** provide a constant-time modular
+      inverse function, but cryptography libraries often do. This is something
+      a security auditor will need to verify for each implementation.
 
 There are additional worries with ECDSA [with different curves](https://safecurves.cr.yp.to/),
 but we side-step most of these problems by hard-coding *one* NIST curve and
 refusing to support any others. The outstanding problems are:
 
 * The NIST curve P-384 [is not rigid](https://safecurves.cr.yp.to/rigid.html).
-  * If you're concerned about NSA backdoors, don't use v3 (which only uses
-    NIST-approved algorithms). Use v4 instead.
+    * If you're concerned about NSA backdoors, don't use v3 (which only uses
+      NIST-approved algorithms). Use v4 instead.
 * Weierstrass curves (such as P-384) historically did not use a
   [constant-time ladder](https://safecurves.cr.yp.to/ladder.html) or offer
   [complete addition formulas](https://safecurves.cr.yp.to/complete.html).
-  * This is more of a problem for ECDH than ECDSA.
-  * [Complete addition formulas for P-384 exist](https://eprint.iacr.org/2015/1060).
+    * This is more of a problem for ECDH than ECDSA.
+    * [Complete addition formulas for P-384 exist](https://eprint.iacr.org/2015/1060).
 
 There are additional protocol-level security concerns for ECDSA, namely:
 
 * Invalid Curve Attacks, which are known to break ECDH.
-  * This is solved in PASETO through requiring support for 
-  [Point Compression](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.202.2977&rep=rep1&type=pdf).
-  * Implementations **MAY** also optionally support PEM encoding of
-    uncompressed public key points, but if they do, they **MUST** validate
-    that the public key is a point on the curve.
-  * Point compression used to be patented, but it expired. It's high time
-    we stopped avoiding its usage as an industry.
+    * This is solved in PASETO through requiring support for
+      [Point Compression](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.202.2977&rep=rep1&type=pdf).
+    * Implementations **MAY** also optionally support PEM encoding of
+      uncompressed public key points, but if they do, they **MUST** validate
+      that the public key is a point on the curve.
+    * Point compression used to be patented, but it expired. It's high time
+      we stopped avoiding its usage as an industry.
 * Exclusive Ownership. [See below.](#v3-signatures-prove-exclusive-ownership-enhancement)
 
 Because of these concerns, we previously forbid any implementation of ECDSA
@@ -89,25 +89,25 @@ risk, there are two things you can do:
 2. Hedged signatures: Inject additional randomness into the RFC 6979 step.
    This randomness doesn't need to be signed.
 
-#### Questions For Security Auditors 
+#### Questions For Security Auditors
 
-Due to the risks inherent to ECDSA, security assessors should take care to 
+Due to the risks inherent to ECDSA, security assessors should take care to
 cover the following questions in any review of a PASETO implementation that
 supports `v3.public` tokens (in addition to their own investigations).
 
 1. Is RFC 6979 supported and used by the implementation?
-   1. If not, is a cryptographically secure random number generator used?
-   2. If the answer to both questions is "No", fail.
+    1. If not, is a cryptographically secure random number generator used?
+    2. If the answer to both questions is "No", fail.
 2. Is modular inversion (`k^-1 (mod p)`) constant-time?
-   1. If not, fail.
+    1. If not, fail.
 3. Are public keys expressed as compressed points?
-   1. If not, is the public key explicitly validated to be on the correct
-      curve (P-384)?
-   2. If the answer to both questions is "No", fail.
+    1. If not, is the public key explicitly validated to be on the correct
+       curve (P-384)?
+    2. If the answer to both questions is "No", fail.
 4. Does the underlying cryptography library use complete addition formulas
    for NIST P-384?
-   1. If not, investigate how the library ensures that scalar multiplication
-      is constant-time. (This affects the security of key generation.)
+    1. If not, investigate how the library ensures that scalar multiplication
+       is constant-time. (This affects the security of key generation.)
 
 Affirmative answers to these questions should provide assurance that the
 ECDSA implementation is safe to use with P-384, and security auditors can
@@ -124,7 +124,7 @@ See below for some broader changes.
 
 The initial motivation for hashing the random nonce with the message was
 to create an SIV-like construction to mitigate the consequences of weak
-random number generators, such as OpenSSL's (which isn't 
+random number generators, such as OpenSSL's (which isn't
 [fork-safe](https://github.com/ramsey/uuid/issues/80)).
 
 However, this creates an unfortunate failure mode: If your RNG fails,
@@ -132,7 +132,7 @@ the resultant nonce is a hash of your message, which can be used to
 perform offline attacks on the plaintext. This was first discovered by
 [Thái Dương](https://twitter.com/XorNinja/status/1157882553610563585).
 
-To avoid this failure mode, neither v3.local nor v4.local will pre-hash 
+To avoid this failure mode, neither v3.local nor v4.local will pre-hash
 the message and random value to derive a nonce. Instead, it will trust
 the CSPRNG to be secure.
 
@@ -169,16 +169,16 @@ security of these constructions is more obvious:
 
 * The probability space for either mode is 256-bits of salt + 256-bits of key,
   for a total of 512 bits.
-  * The HKDF output in v3.local is 384 bits.
-  * The HKDF output in v4.local is 448 bits.
-  * Neither of these output sizes reduces the security against collisions.
-    (If they were larger than the input domain of 512 bits, that would be a
-    blunder.)
+    * The HKDF output in v3.local is 384 bits.
+    * The HKDF output in v4.local is 448 bits.
+    * Neither of these output sizes reduces the security against collisions.
+      (If they were larger than the input domain of 512 bits, that would be a
+      blunder.)
 * A single key can be used for 2^112 PASETOs before rotation is necessary.
-  * The birthday bound for a 256-bit salt is 2^128 (for a 50% chance of
-    a single collision occurring). Setting the safety threshold to 2^-32
-    (which is roughly a 1 in 4 billion chance) for a space of 2^256
-    yields 2^112. 
+    * The birthday bound for a 256-bit salt is 2^128 (for a 50% chance of
+      a single collision occurring). Setting the safety threshold to 2^-32
+      (which is roughly a 1 in 4 billion chance) for a space of 2^256
+      yields 2^112.
 * The actual nonce passed to AES-CTR and XChaCha is not revealed publicly.
 
 ### V3 Signatures Prove Exclusive Ownership (Enhancement)
@@ -217,12 +217,6 @@ when a non-JSON encoding rule is used.
 > respectively. Keys **SHOULD** be portable across different underlying encodings, but tokens
 > **MUST NOT** be transmutable between encodings without access to the symmetric key (`local` tokens)
 > or secret key (`public` tokens).
-
-### Consistent Rules for Footer Parsing
-
-In versions 3 and 4, if a footer is provided, it **MUST** decode to a valid JSON
-string. This ensures that footer processing is consistent across
-PASETO implementations.
 
 ## Questions and Answers
 

--- a/docs/Rationale-V3-V4.md
+++ b/docs/Rationale-V3-V4.md
@@ -204,3 +204,34 @@ forcing function so that all PASETO implementations support compressed points
 since Ed25519 already includes public key with the hash function when signing
 messages. Therefore, we can safely omit this extra step in `v4.public` tokens.
 
+## Questions and Answers
+
+### Why Not AES-GCM in `v3.local`?
+
+While it's true that AES-GCM is more broadly supported in environments that use
+NIST and FIPS-approved cryptography, GMAC is neither
+[message-committing nor key-committing](https://eprint.iacr.org/2019/016).
+
+The techniques for turning an AEAD scheme into an AEAD scheme [is well known](https://eprint.iacr.org/2020/1153),
+but it requires publishing an additional SHA2 hash (or KDF output) of the
+key being used.
+
+Using GCM would require us to also publish an additional hash *anyway*. At
+that point, it doesn't offer any clear advantage over CTR+HMAC.
+
+CTR+HMAC (with separate keys and PAE) is a secure construction and provides
+the cryptographic properties we need to use PASETO in threat models where
+multiple keys are used or [partitioning oracles](https://eprint.iacr.org/2020/1491)
+are possible.
+
+### Why P-384 in `v3.public` instead of P-256 or P-521?
+
+Security experts that work heavily with NIST algorithms expressed a
+slight preference for P-384 over P-521 and P-256 when we asked. This is also
+congruent for our choice of SHA-384 as a hash function over SHA-256 or SHA-512.
+
+The [security considerations](#ecdsa-security) for the NIST curves are mostly
+congruent (albeit the ECDLP security and performance differs a bit).
+
+If you want smaller tokens or better performance than P-384, make sure Ed25519
+lands in FIPS 186-5 and use `v4.public` instead.

--- a/docs/Rationale-V3-V4.md
+++ b/docs/Rationale-V3-V4.md
@@ -78,6 +78,15 @@ However, given the real-world requirements of applications and systems that
 must comply with NIST guidance on cryptography algorithms, we've relaxed this
 requirement.
 
+Additionally, deterministic k-values make signers more susceptible to fault
+attacks than randomized signatures. If you're implementing PASETO signing in
+embedded devices, or environments where fault injection may be a practical
+risk, there are two things you can do:
+
+1. Don't use deterministic signatures because of your specific threat model.
+2. Hedged signatures: Inject additional randomness into the RFC 6979 step.
+   This randomness doesn't need to be signed.
+
 #### Questions For Security Auditors 
 
 Due to the risks inherent to ECDSA, security assessors should take care to 

--- a/docs/Rationale-V3-V4.md
+++ b/docs/Rationale-V3-V4.md
@@ -75,7 +75,9 @@ well for the v4.local proposal.
 For the sake of consistency and easy-to-analyze security designs, in both v3.local
 and v4.local, we now use the entire 32-byte salt in the HKDF step. The nonce
 used by AES-256-CTR and XChaCha20 will be derived from the HKDF output (which
-is now 48 bytes for v3.local and 56 bytes for v4.local).
+is now 48 bytes for v3.local and 56 bytes for v4.local). The first 32 bytes of
+each HKDF output will be used as the key. The remaining bytes will be used as
+the nonce for the underlying cipher.
 
 Local PASETOs in v3 and v4 will always have a predictable storage size, and the
 security of these constructions is more obvious:


### PR DESCRIPTION
# No Code Changes; only specification

See #128 for the implementation.

(Copied from `Rationale-V3-V4.md`)

## Primary Motivations for New Versions

### v4.local

v2.local was originally specified to use XChaCha20-Poly1305, a boring
AEAD mode that's obviously secure. However, we've since learned about
key- and message-commitment, which is an important security property
in systems with multiple possible symmetric keys.

Since PASETO added footers to support key-ids and key rotation
strategies, this means we MUST take attacks that depend on
[random-key robustness](https://eprint.iacr.org/2020/1491) seriously.

PASETO v4.local uses XChaCha20 to encrypt the message, but then uses
a keyed BLAKE2b hash (which acts as HMAC) for the authentication tag.

### v3.public

We specified RSA for PASETO v1.public tokens, under the assumption that
applications that must ONLY support NIST algorithms (e.g. because they
MUST only use FIPS 140-2 validated modules to maintain compliance) would
be adequately served by RSA signatures. This assumption turned out to be
incorrect, and elliptic curve cryptography is now preferred.

To better meet the needs of applications that are NIST-dependent, PASETO
v3.public tokens will support ECDSA over NIST's P-384 curve, with SHA-384,
and (preferably) using RFC 6979 deterministic signatures. (RFC 6979 is a
**SHOULD**, not a **MUST**, due to library availability issues and
[fault attacks](https://eprint.iacr.org/2017/1014).)

#### ECDSA Security

ECDSA is much more dangerous to implement than Ed25519:

1. You have to ensure the one-time secret `k` is never reused for different
   messages, or you leak your secret key.
2. If you're not generating `k` deterministically, you have to take extra
   care to ensure your random number generator isn't biased. If you fail
   to ensure this, attackers can determine your secret key through
   [lattice attacks](https://eprint.iacr.org/2019/023).
3. The computing `k^-1 (mod p)` must be constant-time to avoid leaking `k`.
    * Most bignum libraries **DO NOT** provide a constant-time modular
      inverse function, but cryptography libraries often do. This is something
      a security auditor will need to verify for each implementation.

There are additional worries with ECDSA [with different curves](https://safecurves.cr.yp.to/),
but we side-step most of these problems by hard-coding *one* NIST curve and
refusing to support any others. The outstanding problems are:

* The NIST curve P-384 [is not rigid](https://safecurves.cr.yp.to/rigid.html).
    * If you're concerned about NSA backdoors, don't use v3 (which only uses
      NIST-approved algorithms). Use v4 instead.
* Weierstrass curves (such as P-384) historically did not use a
  [constant-time ladder](https://safecurves.cr.yp.to/ladder.html) or offer
  [complete addition formulas](https://safecurves.cr.yp.to/complete.html).
    * This is more of a problem for ECDH than ECDSA.
    * [Complete addition formulas for P-384 exist](https://eprint.iacr.org/2015/1060).

There are additional protocol-level security concerns for ECDSA, namely:

* Invalid Curve Attacks, which are known to break ECDH.
    * This is solved in PASETO through requiring support for
      [Point Compression](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.202.2977&rep=rep1&type=pdf).
    * Implementations **MAY** also optionally support PEM encoding of
      uncompressed public key points, but if they do, they **MUST** validate
      that the public key is a point on the curve.
    * Point compression used to be patented, but it expired. It's high time
      we stopped avoiding its usage as an industry.
* Exclusive Ownership. [See below.](#v3-signatures-prove-exclusive-ownership-enhancement)

Because of these concerns, we previously forbid any implementation of ECDSA
*without* RFC 6979 deterministic k-values in a future version.

However, given the real-world requirements of applications and systems that
must comply with NIST guidance on cryptography algorithms, we've relaxed this
requirement.

Additionally, deterministic k-values make signers more susceptible to fault
attacks than randomized signatures. If you're implementing PASETO signing in
embedded devices, or environments where fault injection may be a practical
risk, there are two things you can do:

1. Don't use deterministic signatures because of your specific threat model.
2. Hedged signatures: Inject additional randomness into the RFC 6979 step.
   This randomness doesn't need to be signed.

#### Questions For Security Auditors

Due to the risks inherent to ECDSA, security assessors should take care to
cover the following questions in any review of a PASETO implementation that
supports `v3.public` tokens (in addition to their own investigations).

1. Is RFC 6979 supported and used by the implementation?
    1. If not, is a cryptographically secure random number generator used?
    2. If the answer to both questions is "No", fail.
2. Is modular inversion (`k^-1 (mod p)`) constant-time?
    1. If not, fail.
3. Are public keys expressed as compressed points?
    1. If not, is the public key explicitly validated to be on the correct
       curve (P-384)?
    2. If the answer to both questions is "No", fail.
4. Does the underlying cryptography library use complete addition formulas
   for NIST P-384?
    1. If not, investigate how the library ensures that scalar multiplication
       is constant-time. (This affects the security of key generation.)

Affirmative answers to these questions should provide assurance that the
ECDSA implementation is safe to use with P-384, and security auditors can
focus their attention on other topics of interest.

### v3.local / v4.public

No specific changes were needed from (v1.local, v2.public) respectively.
See below for some broader changes.

## Beneficial Changes to V3/V4

### No More Nonce-Hashing (Change)

The initial motivation for hashing the random nonce with the message was
to create an SIV-like construction to mitigate the consequences of weak
random number generators, such as OpenSSL's (which isn't
[fork-safe](https://github.com/ramsey/uuid/issues/80)).

However, this creates an unfortunate failure mode: If your RNG fails,
the resultant nonce is a hash of your message, which can be used to
perform offline attacks on the plaintext. This was first discovered by
[Thái Dương](https://twitter.com/XorNinja/status/1157882553610563585).

To avoid this failure mode, neither v3.local nor v4.local will pre-hash
the message and random value to derive a nonce. Instead, it will trust
the CSPRNG to be secure.

### Implicit Assertions (Feature)

PASETO v3 and v4 tokens will support optional additional authenticated
data that **IS NOT** stored in the token, but **IS USED** to calculate the
authentication tag (local) or signature (public).

These are called **implicit assertions**. These can be any application-specific
data that must be provided when validating tokens, but isn't appropriate to
store in the token itself (e.g. sensitive internal values).

One example where implicit assertions might be desirable is ensuring that a PASETO
is only used by a specific user in a multi-tenant system. Simply providing the
user's account ID when minting and consuming PASETOs will bind the token to the
desired context.

### Better Use of HKDF Salts (Change)

With v1.local, half of the 32-byte random value was used as an HKDF salt and
half was used as an AES-CTR nonce. This is tricky to analyze and didn't extend
well for the v4.local proposal.

For the sake of consistency and easy-to-analyze security designs, in both v3.local
and v4.local, we now use the entire 32-byte random value in the HKDF step.

Instead of being used as a salt, however, it will be appended to the info tag.
This subtle change allows us to use the 
[standard security definition for HKDF](https://eprint.iacr.org/2010/264)
in arguments for PASETO's security, rather than treating it as just a
pseudo-random function (PRF). This security definition requires only one salt
to be used, but for many contexts (info tags).

The nonce used by AES-256-CTR and XChaCha20 will be derived from the HKDF output
(which is now 48 bytes for v3.local and 56 bytes for v4.local). The first 32
bytes of each HKDF output will be used as the key. The remaining bytes will be 
used as the nonce for the underlying cipher.

Local PASETOs in v3 and v4 will always have a predictable storage size, and the
security of these constructions is more obvious:

* The probability space for either mode is 256-bits of randomness + 256-bits of
  key, for a total of 512 bits.
    * The HKDF output in v3.local is 384 bits.
    * The HKDF output in v4.local is 448 bits.
    * Neither of these output sizes reduces the security against collisions.
      (If they were larger than the input domain of 512 bits, that would be a
      blunder.)
* A single key can be used for 2^112 PASETOs before rotation is necessary.
    * The birthday bound for a 256-bit salt is 2^128 (for a 50% chance of
      a single collision occurring). Setting the safety threshold to 2^-32
      (which is roughly a 1 in 4 billion chance) for a space of 2^256
      yields 2^112.
* The actual nonce passed to AES-CTR and XChaCha is not revealed publicly.

### V3 Signatures Prove Exclusive Ownership (Enhancement)

RSA and ECDSA signatures [do not prove Exclusive Ownership](http://www.bolet.org/~pornin/2005-acns-pornin+stern.pdf).
This is almost never a problem for most protocols, unless you *expect* this property
to hold when it doesn't.

Section 3.3 of the paper linked above describes how to achieve Universal Exclusive
Ownership (UEO) without increasing the signature size: Always include the public
key in the message that's being signed.

Consequently, `v3.public` PASETOs will include the raw bytes of the public
key in the PAE step for calculating signatures. The public key is always a
compressed point (`0x02` or `0x03`, followed by the X coordinate, for a total
of 49 bytes).

We decided to use point compression in the construction of the tokens as a
forcing function so that all PASETO implementations support compressed points
(and don't just phone it in with PEM-encoded uncompressed points).

[Ed25519, by design, does not suffer from this](https://eprint.iacr.org/2020/823),
since Ed25519 already includes public key with the hash function when signing
messages. Therefore, we can safely omit this extra step in `v4.public` tokens.

## Miscellaneous Changes

### Define Mechanism for Extending PASETO for non-JSON Encodings

PASETO serializes its payload as a JSON string. Future documents **MAY** specify using
PASETO with non-JSON encoding. When this happens, a suffix will be appended to the version tag
when a non-JSON encoding rule is used.

> For example, a future PASETO-CBOR proposal might define its versions as `v1c`, `v2c`, `v3c`,
> and `v4c`. The underlying cryptography will be the same as `v1`, `v2`, `v3`, and `v4`
> respectively. Keys **SHOULD** be portable across different underlying encodings, but tokens
> **MUST NOT** be transmutable between encodings without access to the symmetric key (`local` tokens)
> or secret key (`public` tokens).

## Questions and Answers

### Why Not AES-GCM in `v3.local`?

While it's true that AES-GCM is more broadly supported in environments that use
NIST and FIPS-approved cryptography, GMAC is neither
[message-committing nor key-committing](https://eprint.iacr.org/2019/016).

The techniques for turning an AEAD scheme into an AEAD scheme [is well known](https://eprint.iacr.org/2020/1153),
but it requires publishing an additional SHA2 hash (or KDF output) of the
key being used.

Using GCM would require us to also publish an additional hash *anyway*. At
that point, it doesn't offer any clear advantage over CTR+HMAC.

CTR+HMAC (with separate keys and PAE) is a secure construction and provides
the cryptographic properties we need to use PASETO in threat models where
multiple keys are used or [partitioning oracles](https://eprint.iacr.org/2020/1491)
are possible.

### Why P-384 in `v3.public` instead of P-256 or P-521?

Security experts that work heavily with NIST algorithms expressed a
slight preference for P-384 over P-521 and P-256 when we asked. This is also
congruent for our choice of SHA-384 as a hash function over SHA-256 or SHA-512.

The [security considerations](#ecdsa-security) for the NIST curves are mostly
congruent (albeit the ECDLP security and performance differs a bit).

If you want smaller tokens or better performance than P-384, make sure Ed25519
lands in FIPS 186-5 and use `v4.public` instead.
