### PR TITLE
Deprecate Version1 and Version2

### DIFF
--- a/src/Keys/AsymmetricPublicKey.php
+++ b/src/Keys/AsymmetricPublicKey.php
@@ -93,6 +93,8 @@ class AsymmetricPublicKey implements ReceivingKey
      * @return self
      *
      * @throws Exception
+     *
+     * @deprecated See Version3 instead.
      */
     public static function v1(string $keyMaterial): self
     {
@@ -106,6 +108,8 @@ class AsymmetricPublicKey implements ReceivingKey
      * @return self
      *
      * @throws Exception
+     *
+     * @deprecated See Version4 instead.
      */
     public static function v2(string $keyMaterial): self
     {

--- a/src/Keys/AsymmetricSecretKey.php
+++ b/src/Keys/AsymmetricSecretKey.php
@@ -97,6 +97,8 @@ class AsymmetricSecretKey implements SendingKey
      *
      * @throws Exception
      * @throws TypeError
+     *
+     * @deprecated See Version3 instead.
      */
     public static function v1(string $keyMaterial): self
     {
@@ -111,6 +113,8 @@ class AsymmetricSecretKey implements SendingKey
      *
      * @throws Exception
      * @throws TypeError
+     *
+     * @deprecated See Version4 instead.
      */
     public static function v2(string $keyMaterial): self
     {

--- a/src/Keys/SymmetricKey.php
+++ b/src/Keys/SymmetricKey.php
@@ -85,6 +85,8 @@ class SymmetricKey implements ReceivingKey, SendingKey
      *
      * @throws Exception
      * @throws TypeError
+     *
+     * @deprecated See Version3 instead.
      */
     public static function v1(string $keyMaterial): self
     {
@@ -100,6 +102,8 @@ class SymmetricKey implements ReceivingKey, SendingKey
      *
      * @throws Exception
      * @throws TypeError
+     *
+     * @deprecated See Version4 instead.
      */
     public static function v2(string $keyMaterial): self
     {

--- a/src/Keys/Version1/AsymmetricPublicKey.php
+++ b/src/Keys/Version1/AsymmetricPublicKey.php
@@ -11,6 +11,8 @@ use TypeError;
 /**
  * Class AsymmetricPublicKey
  * @package ParagonIE\Paseto\Keys\Version1
+ *
+ * @deprecated See Version3 instead.
  */
 class AsymmetricPublicKey extends BasePublicKey
 {

--- a/src/Keys/Version1/AsymmetricSecretKey.php
+++ b/src/Keys/Version1/AsymmetricSecretKey.php
@@ -11,6 +11,8 @@ use TypeError;
 /**
  * Class AsymmetricSecretKey
  * @package ParagonIE\Paseto\Keys\Version1
+ *
+ * @deprecated See Version3 instead.
  */
 class AsymmetricSecretKey extends BaseSecretKey
 {

--- a/src/Keys/Version1/SymmetricKey.php
+++ b/src/Keys/Version1/SymmetricKey.php
@@ -9,6 +9,8 @@ use ParagonIE\Paseto\ProtocolInterface;
 /**
  * Class SymmetricKey
  * @package ParagonIE\Paseto\Keys\Version1
+ *
+ * @deprecated See Version3 instead.
  */
 class SymmetricKey extends BaseSymmetricKey
 {

--- a/src/Keys/Version2/AsymmetricPublicKey.php
+++ b/src/Keys/Version2/AsymmetricPublicKey.php
@@ -11,6 +11,8 @@ use TypeError;
 /**
  * Class AsymmetricPublicKey
  * @package ParagonIE\Paseto\Keys\Version2
+ *
+ * @deprecated See Version4 instead.
  */
 class AsymmetricPublicKey extends BasePublicKey
 {

--- a/src/Keys/Version2/AsymmetricSecretKey.php
+++ b/src/Keys/Version2/AsymmetricSecretKey.php
@@ -11,6 +11,8 @@ use TypeError;
 /**
  * Class AsymmetricSecretKey
  * @package ParagonIE\Paseto\Keys\Version2
+ *
+ * @deprecated See Version4 instead.
  */
 class AsymmetricSecretKey extends BaseSecretKey
 {

--- a/src/Keys/Version2/SymmetricKey.php
+++ b/src/Keys/Version2/SymmetricKey.php
@@ -9,6 +9,8 @@ use ParagonIE\Paseto\ProtocolInterface;
 /**
  * Class SymmetricKey
  * @package ParagonIE\Paseto\Keys\Version2
+ *
+ * @deprecated See Version4 instead.
  */
 class SymmetricKey extends BaseSymmetricKey
 {

--- a/src/Protocol/Version1.php
+++ b/src/Protocol/Version1.php
@@ -50,6 +50,8 @@ use function define,
 /**
  * Class Version1
  * @package ParagonIE\Paseto\Protocol
+ *
+ * @deprecated See Version3 instead.
  */
 class Version1 implements ProtocolInterface
 {

--- a/src/Protocol/Version2.php
+++ b/src/Protocol/Version2.php
@@ -45,6 +45,8 @@ use function hash_equals,
 /**
  * Class Version1
  * @package ParagonIE\Paseto\Protocol
+ *
+ * @deprecated See Version4 instead.
  */
 class Version2 implements ProtocolInterface
 {

--- a/src/ProtocolCollection.php
+++ b/src/ProtocolCollection.php
@@ -162,6 +162,8 @@ final class ProtocolCollection
      *
      * @throws InvalidVersionException
      * @throws SecurityException
+     *
+     * @deprecated See Version3 instead.
      */
     public static function v1(): self
     {
@@ -174,6 +176,8 @@ final class ProtocolCollection
      * @return self
      *
      * @throws InvalidVersionException
+     *
+     * @deprecated See Version4 instead.
      */
     public static function v2(): self
     {


### PR DESCRIPTION
See https://github.com/paragonie/paseto-io/issues/32 and https://github.com/paseto-standard/paseto-spec/pull/13

We're currently targeting 2022-01-01 for the deprecation date.