### PR TITLE
Remove misleading implicit param from v1 and v2

### DIFF
--- a/src/ImplicitProtocolInterface.php
+++ b/src/ImplicitProtocolInterface.php
@@ -12,48 +12,22 @@ use ParagonIE\Paseto\Keys\{
  * Interface ProtocolInterface
  * @package ParagonIE\Paseto
  */
-interface ProtocolInterface
+interface ImplicitProtocolInterface extends ProtocolInterface
 {
-    /**
-     * Must be constructable with no arguments so an instance may be passed
-     * around in a type safe way.
-     */
-    public function __construct();
-
-    /**
-     * A unique header string with which the protocol can be identified.
-     *
-     * @return string
-     */
-    public static function header(): string;
-
-    /**
-     * @return AsymmetricSecretKey
-     */
-    public static function generateAsymmetricSecretKey(): AsymmetricSecretKey;
-
-    /**
-     * @return SymmetricKey
-     */
-    public static function generateSymmetricKey(): SymmetricKey;
-
-    /**
-     * @return int
-     */
-    public static function getSymmetricKeyByteLength(): int;
-
     /**
      * Encrypt a message using a shared key.
      *
      * @param string $data
      * @param SymmetricKey $key
      * @param string $footer
+     * @param string $implicit
      * @return string
      */
     public static function encrypt(
         string $data,
         SymmetricKey $key,
-        string $footer = ''
+        string $footer = '',
+        string $implicit = ''
     ): string;
 
     /**
@@ -62,12 +36,14 @@ interface ProtocolInterface
      * @param string $data
      * @param SymmetricKey $key
      * @param string|null $footer
+     * @param string $implicit
      * @return string
      */
     public static function decrypt(
         string $data,
         SymmetricKey $key,
-        string $footer = null
+        string $footer = null,
+        string $implicit = ''
     ): string;
 
     /**
@@ -76,12 +52,14 @@ interface ProtocolInterface
      * @param string $data
      * @param AsymmetricSecretKey $key
      * @param string $footer
+     * @param string $implicit
      * @return string
      */
     public static function sign(
         string $data,
         AsymmetricSecretKey $key,
-        string $footer = ''
+        string $footer = '',
+        string $implicit = ''
     ): string;
 
     /**
@@ -90,11 +68,13 @@ interface ProtocolInterface
      * @param string $signMsg
      * @param AsymmetricPublicKey $key
      * @param string|null $footer
+     * @param string $implicit
      * @return string
      */
     public static function verify(
         string $signMsg,
         AsymmetricPublicKey $key,
-        string $footer = null
+        string $footer = null,
+        string $implicit = ''
     ): string;
 }

--- a/src/ImplicitProtocolInterface.php
+++ b/src/ImplicitProtocolInterface.php
@@ -15,6 +15,14 @@ use ParagonIE\Paseto\Keys\{
 interface ImplicitProtocolInterface extends ProtocolInterface
 {
     /**
+     * Does this protocol support implicit assertions?
+     *
+     * @return bool
+     * @psalm-return true
+     */
+    public static function supportsImplicitAssertions(): bool;
+
+    /**
      * Encrypt a message using a shared key.
      *
      * @param string $data

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -398,7 +398,7 @@ class Parser extends PasetoBase
 
         $implicit = '';
         if (!empty($this->implicitAssertions)) {
-            if (!$protocol::supportsImplicitAssertions()) {
+            if (!($protocol instanceof ImplicitProtocolInterface)) {
                 throw new PasetoException(
                     'This version does not support implicit assertions',
                     ExceptionCode::IMPLICIT_ASSERTION_NOT_SUPPORTED
@@ -416,7 +416,11 @@ class Parser extends PasetoBase
                 $key = $this->fetchSymmetricKey($keyId);
 
                 try {
-                    $decoded = $protocol::decrypt($tainted, $key, $footer, $implicit);
+                    if ($protocol instanceof ImplicitProtocolInterface) {
+                        $decoded = $protocol::decrypt($tainted, $key, $footer, $implicit);
+                    } else {
+                        $decoded = $protocol::decrypt($tainted, $key, $footer);
+                    }
                 } catch (Throwable $ex) {
                     throw new PasetoException(
                         'An error occurred',
@@ -429,7 +433,11 @@ class Parser extends PasetoBase
                 // An asymmetric public key is, by type-safety, suitable for public tokens
                 $key = $this->fetchPublicKey($keyId);
                 try {
-                    $decoded = $protocol::verify($tainted, $key, $footer, $implicit);
+                    if ($protocol instanceof ImplicitProtocolInterface) {
+                        $decoded = $protocol::verify($tainted, $key, $footer, $implicit);
+                    } else {
+                        $decoded = $protocol::verify($tainted, $key, $footer);
+                    }
                 } catch (Throwable $ex) {
                     throw new PasetoException(
                         'An error occurred',

--- a/src/Protocol/Version1.php
+++ b/src/Protocol/Version1.php
@@ -128,23 +128,11 @@ class Version1 implements ProtocolInterface
     }
 
     /**
-     * Does this protocol support implicit assertions?
-     * No.
-     *
-     * @return bool
-     */
-    public static function supportsImplicitAssertions(): bool
-    {
-        return false;
-    }
-
-    /**
      * Encrypt a message using a shared key.
      *
      * @param string $data
      * @param SymmetricKey $key
      * @param string $footer
-     * @param string $implicit
      * @return string
      * @throws PasetoException
      * @throws TypeError
@@ -152,8 +140,7 @@ class Version1 implements ProtocolInterface
     public static function encrypt(
         string $data,
         SymmetricKey $key,
-        string $footer = '',
-        string $implicit = ''
+        string $footer = ''
     ): string {
         return self::__encrypt($data, $key, $footer);
     }
@@ -164,7 +151,6 @@ class Version1 implements ProtocolInterface
      * @param string $data
      * @param SymmetricKey $key
      * @param string $footer
-     * @param string $implicit
      * @param string $nonceForUnitTesting
      * @return string
      *
@@ -176,7 +162,6 @@ class Version1 implements ProtocolInterface
         string $data,
         SymmetricKey $key,
         string $footer = '',
-        string $implicit = '',
         string $nonceForUnitTesting = ''
     ): string {
         /*
@@ -206,7 +191,6 @@ class Version1 implements ProtocolInterface
      * @param string $data
      * @param SymmetricKey $key
      * @param string|null $footer
-     * @param string $implicit
      * @return string
      *
      * @throws PasetoException
@@ -216,8 +200,7 @@ class Version1 implements ProtocolInterface
     public static function decrypt(
         string $data,
         SymmetricKey $key,
-        string $footer = null,
-        string $implicit = ''
+        string $footer = null
     ): string {
         /*
          * PASETO Version 1 - Decrypt - Step 1
@@ -252,7 +235,6 @@ class Version1 implements ProtocolInterface
      * @param string $data
      * @param AsymmetricSecretKey $key
      * @param string $footer
-     * @param string $implicit
      * @return string
      *
      * @throws TypeError
@@ -262,8 +244,7 @@ class Version1 implements ProtocolInterface
     public static function sign(
         string $data,
         AsymmetricSecretKey $key,
-        string $footer = '',
-        string $implicit = ''
+        string $footer = ''
     ): string {
         /*
          * PASETO Version 1 - Sign - Step 1
@@ -300,7 +281,6 @@ class Version1 implements ProtocolInterface
      * @param string $signMsg
      * @param AsymmetricPublicKey $key
      * @param string|null $footer
-     * @param string $implicit
      * @return string
      *
      * @throws PasetoException
@@ -309,8 +289,7 @@ class Version1 implements ProtocolInterface
     public static function verify(
         string $signMsg,
         AsymmetricPublicKey $key,
-        string $footer = null,
-        string $implicit = ''
+        string $footer = null
     ): string {
         /*
          * PASETO Version 1 - Verify - Step 1

--- a/src/Protocol/Version1.php
+++ b/src/Protocol/Version1.php
@@ -128,6 +128,18 @@ class Version1 implements ProtocolInterface
     }
 
     /**
+     * Does this protocol support implicit assertions?
+     * No.
+     *
+     * @return bool
+     * @psalm-return false
+     */
+    public static function supportsImplicitAssertions(): bool
+    {
+        return false;
+    }
+
+    /**
      * Encrypt a message using a shared key.
      *
      * @param string $data

--- a/src/Protocol/Version2.php
+++ b/src/Protocol/Version2.php
@@ -69,6 +69,18 @@ class Version2 implements ProtocolInterface
     }
 
     /**
+     * Does this protocol support implicit assertions?
+     * No.
+     *
+     * @return bool
+     * @psalm-return false
+     */
+    public static function supportsImplicitAssertions(): bool
+    {
+        return false;
+    }
+
+    /**
      * @return int
      */
     public static function getSymmetricKeyByteLength(): int

--- a/src/Protocol/Version2.php
+++ b/src/Protocol/Version2.php
@@ -69,17 +69,6 @@ class Version2 implements ProtocolInterface
     }
 
     /**
-     * Does this protocol support implicit assertions?
-     * No.
-     *
-     * @return bool
-     */
-    public static function supportsImplicitAssertions(): bool
-    {
-        return false;
-    }
-
-    /**
      * @return int
      */
     public static function getSymmetricKeyByteLength(): int
@@ -119,7 +108,6 @@ class Version2 implements ProtocolInterface
      * @param string $data
      * @param SymmetricKey $key
      * @param string $footer
-     * @param string $implicit (Unused)
      * @return string
      *
      * @throws PasetoException
@@ -129,8 +117,7 @@ class Version2 implements ProtocolInterface
     public static function encrypt(
         string $data,
         SymmetricKey $key,
-        string $footer = '',
-        string $implicit = ''
+        string $footer = ''
     ): string {
         return self::__encrypt($data, $key, $footer);
     }
@@ -141,7 +128,6 @@ class Version2 implements ProtocolInterface
      * @param string $data
      * @param SymmetricKey $key
      * @param string $footer
-     * @param string $implicit (Unused)
      * @param string $nonceForUnitTesting
      * @return string
      *
@@ -153,7 +139,6 @@ class Version2 implements ProtocolInterface
         string $data,
         SymmetricKey $key,
         string $footer = '',
-        string $implicit = '',
         string $nonceForUnitTesting = ''
     ): string {
         /*
@@ -183,7 +168,6 @@ class Version2 implements ProtocolInterface
      * @param string $data
      * @param SymmetricKey $key
      * @param string|null $footer
-     * @param string $implicit (Unused)
      * @return string
      *
      * @throws PasetoException
@@ -193,8 +177,7 @@ class Version2 implements ProtocolInterface
     public static function decrypt(
         string $data,
         SymmetricKey $key,
-        string $footer = null,
-        string $implicit = ''
+        string $footer = null
     ): string {
         /*
          * PASETO Version 2 - Decrypt - Step 1
@@ -237,7 +220,6 @@ class Version2 implements ProtocolInterface
      * @param string $data
      * @param AsymmetricSecretKey $key
      * @param string $footer
-     * @param string $implicit (Unused)
      * @return string
      *
      * @throws PasetoException
@@ -247,8 +229,7 @@ class Version2 implements ProtocolInterface
     public static function sign(
         string $data,
         AsymmetricSecretKey $key,
-        string $footer = '',
-        string $implicit = ''
+        string $footer = ''
     ): string {
         /*
          * PASETO Version 2 - Sign - Step 1
@@ -286,7 +267,6 @@ class Version2 implements ProtocolInterface
      * @param string $signMsg
      * @param AsymmetricPublicKey $key
      * @param string|null $footer
-     * @param string $implicit (Unused)
      * @return string
      *
      * @throws PasetoException
@@ -296,8 +276,7 @@ class Version2 implements ProtocolInterface
     public static function verify(
         string $signMsg,
         AsymmetricPublicKey $key,
-        string $footer = null,
-        string $implicit = ''
+        string $footer = null
     ): string {
         /*
          * PASETO Version 2 - Verify - Step 1

--- a/src/Protocol/Version3.php
+++ b/src/Protocol/Version3.php
@@ -119,6 +119,18 @@ class Version3 implements ImplicitProtocolInterface
     }
 
     /**
+     * Does this protocol support implicit assertions?
+     * Yes.
+     *
+     * @return bool
+     * @psalm-return true
+     */
+    public static function supportsImplicitAssertions(): bool
+    {
+        return true;
+    }
+
+    /**
      * Encrypt a message using a shared key.
      *
      * @param string $data

--- a/src/Protocol/Version3.php
+++ b/src/Protocol/Version3.php
@@ -30,7 +30,7 @@ use ParagonIE\EasyECC\ECDSA\{
     SecretKey
 };
 use ParagonIE\Paseto\{
-    ProtocolInterface,
+    ImplicitProtocolInterface,
     Util
 };
 use ParagonIE\Paseto\Parsing\{
@@ -53,7 +53,7 @@ use function hash_equals,
  * Class Version1
  * @package ParagonIE\Paseto\Protocol
  */
-class Version3 implements ProtocolInterface
+class Version3 implements ImplicitProtocolInterface
 {
     const HEADER = 'v3';
     const CIPHER_MODE = 'aes-256-ctr';
@@ -116,17 +116,6 @@ class Version3 implements ProtocolInterface
     public static function header(): string
     {
         return (string) static::HEADER;
-    }
-
-    /**
-     * Does this protocol support implicit assertions?
-     * Yes.
-     *
-     * @return bool
-     */
-    public static function supportsImplicitAssertions(): bool
-    {
-        return true;
     }
 
     /**

--- a/src/Protocol/Version4.php
+++ b/src/Protocol/Version4.php
@@ -106,6 +106,18 @@ class Version4 implements ImplicitProtocolInterface
     }
 
     /**
+     * Does this protocol support implicit assertions?
+     * Yes.
+     *
+     * @return bool
+     * @psalm-return true
+     */
+    public static function supportsImplicitAssertions(): bool
+    {
+        return true;
+    }
+
+    /**
      * Encrypt a message using a shared key.
      *
      * @param string $data

--- a/src/Protocol/Version4.php
+++ b/src/Protocol/Version4.php
@@ -22,7 +22,7 @@ use ParagonIE\Paseto\Exception\{
     SecurityException
 };
 use ParagonIE\Paseto\{
-    ProtocolInterface,
+    ImplicitProtocolInterface,
     Util
 };
 use ParagonIE\Paseto\Parsing\{
@@ -45,7 +45,7 @@ use function hash_equals,
  * Class Version1
  * @package ParagonIE\Paseto\Protocol
  */
-class Version4 implements ProtocolInterface
+class Version4 implements ImplicitProtocolInterface
 {
     /** @const string HEADER */
     const HEADER = 'v4';
@@ -103,17 +103,6 @@ class Version4 implements ProtocolInterface
     public static function header(): string
     {
         return (string) static::HEADER;
-    }
-
-    /**
-     * Does this protocol support implicit assertions?
-     * Yes.
-     *
-     * @return bool
-     */
-    public static function supportsImplicitAssertions(): bool
-    {
-        return true;
     }
 
     /**

--- a/src/ProtocolInterface.php
+++ b/src/ProtocolInterface.php
@@ -28,6 +28,13 @@ interface ProtocolInterface
     public static function header(): string;
 
     /**
+     * Does this protocol support implicit assertions?
+     *
+     * @return bool
+     */
+    public static function supportsImplicitAssertions(): bool;
+
+    /**
      * @return AsymmetricSecretKey
      */
     public static function generateAsymmetricSecretKey(): AsymmetricSecretKey;

--- a/tests/JsonTokenTest.php
+++ b/tests/JsonTokenTest.php
@@ -38,7 +38,7 @@ class JsonTokenTest extends TestCase
             ->set('data', 'this is a signed message')
             ->setExpiration(new \DateTime('2039-01-01T00:00:00+00:00'));
 
-        NonceFixer::buildSetExplicitNonce()->bindTo($builder, $builder)($nonce);
+        NonceFixer::buildSetExplicitNonce(true)->bindTo($builder, $builder)($nonce);
 
         $this->assertSame(
             'v4.local.RXQsl21oT_hOvcDeWYCal82i9kyE_aGb6hs4MANpkKEzSOVPaHQVrE_TyDA7Pe37zn1qQykJeCi6_WZVov-PkRU5F6ANACIZKUXgzN9gucaifEsf4TFPuDoiz_k0PwaUM222jY1TPwYUHvx50GN4veVKo-aFbctcZjqg6MA',
@@ -95,7 +95,7 @@ class JsonTokenTest extends TestCase
             ->setExpiration(new \DateTime('2039-01-01T00:00:00+00:00'))
             ->setFooterArray($footerArray);
 
-        NonceFixer::buildSetExplicitNonce()->bindTo($builder, $builder)($nonce);
+        NonceFixer::buildSetExplicitNonce(true)->bindTo($builder, $builder)($nonce);
 
         $first = (string) $builder;
         $alt = $builder->with('data', 'this is a different message');
@@ -150,7 +150,7 @@ class JsonTokenTest extends TestCase
             ->setExpiration(new \DateTime('2039-01-01T00:00:00+00:00'))
             ->setFooterArray($footerArray);
 
-        NonceFixer::buildSetExplicitNonce()->bindTo($builder, $builder)($nonce);
+        NonceFixer::buildSetExplicitNonce(true)->bindTo($builder, $builder)($nonce);
 
         $this->assertSame(
             'v4.local.RXQsl21oT_hOvcDeWYCal82i9kyE_aGb6hs4MANpkKEzSOVPaHQVrE_TyDA7Pe37zn1qQykJeCi6_WZVov-PkRU5F6ANACIZKUXgzN9gucaifEsf4TFPuDoiz_k0AMr750FXTBgsZercGCHkWLxy62xRbZTIHlIGaxDekO4.eyJrZXktaWQiOiJnYW5kYWxmMCJ9',

--- a/tests/KnownAnswerTest.php
+++ b/tests/KnownAnswerTest.php
@@ -102,7 +102,7 @@ class KnownAnswerTest extends TestCase
                         $decoded = $protocol::verify(
                             $test['token'],
                             $this->cacheKey($protocol, $test['public-key'], true),
-                            $test['footer'] ?? '',
+                            $test['footer'] ?? ''
                         );
                     }
                 } elseif (isset($test['key'])) {

--- a/tests/NonceFixer.php
+++ b/tests/NonceFixer.php
@@ -3,10 +3,11 @@ declare(strict_types=1);
 namespace ParagonIE\Paseto\Tests;
 
 use ParagonIE\Paseto\ProtocolInterface;
+use ParagonIE\Paseto\ImplicitProtocolInterface;
 use ParagonIE\Paseto\Keys\SymmetricKey;
 
 abstract class NonceFixer {
-    public static function buildUnitTestEncrypt(ProtocolInterface $protocol): \Closure {
+    public static function buildUnitTestImplicitEncrypt(ImplicitProtocolInterface $protocol): \Closure {
         return static function (
             string $data,
             SymmetricKey $key,
@@ -18,39 +19,80 @@ abstract class NonceFixer {
         };
     }
 
-    public static function buildSetExplicitNonce(): \Closure {
-        return function (string $nonce) {
+    public static function buildUnitTestNonImplicitEncrypt(ProtocolInterface $protocol): \Closure {
+        return static function (
+            string $data,
+            SymmetricKey $key,
+            string $footer = '',
+            string $nonceForUnitTesting = ''
+        ) use ($protocol): string {
+            return $protocol::__encrypt($data, $key, $footer, $nonceForUnitTesting);
+        };
+    }
+
+    public static function buildSetExplicitNonce(bool $isImplicit): \Closure {
+        return function (string $nonce) use ($isImplicit) {
             /** @noinspection Annotator */
-            $this->unitTestEncrypter = static function (ProtocolInterface $protocol) use ($nonce) {
-                $class = new class {
-                    private static $nonce;
-                    private static $protocol;
+            $this->unitTestEncrypter = static function (ProtocolInterface $protocol) use ($nonce, $isImplicit) {
+                if ($isImplicit) {
+                    $class = new class {
+                        private static $nonce;
+                        private static $protocol;
 
-                    public static function setNonce(string $nonce)
-                    {
-                        self::$nonce = $nonce;
-                    }
+                        public static function setNonce(string $nonce)
+                        {
+                            self::$nonce = $nonce;
+                        }
 
-                    public static function setProtocol(ProtocolInterface $protocol)
-                    {
-                        self::$protocol = $protocol;
-                    }
+                        public static function setProtocol(ProtocolInterface $protocol)
+                        {
+                            self::$protocol = $protocol;
+                        }
 
-                    public static function encrypt(
-                        string $data,
-                        SymmetricKey $key,
-                        string $footer = '',
-                        string $implicit = ''
-                    ): string {
-                        return NonceFixer::buildUnitTestEncrypt(self::$protocol)->bindTo(null, self::$protocol)(
-                            $data,
-                            $key,
-                            $footer,
-                            $implicit,
-                            self::$nonce
-                        );
-                    }
-                };
+                        public static function encrypt(
+                            string $data,
+                            SymmetricKey $key,
+                            string $footer = '',
+                            string $implicit = ''
+                        ): string {
+                            return NonceFixer::buildUnitTestImplicitEncrypt(self::$protocol)->bindTo(null, self::$protocol)(
+                                $data,
+                                $key,
+                                $footer,
+                                $implicit,
+                                self::$nonce
+                            );
+                        }
+                    };
+                } else {
+                    $class = new class {
+                        private static $nonce;
+                        private static $protocol;
+
+                        public static function setNonce(string $nonce)
+                        {
+                            self::$nonce = $nonce;
+                        }
+
+                        public static function setProtocol(ProtocolInterface $protocol)
+                        {
+                            self::$protocol = $protocol;
+                        }
+
+                        public static function encrypt(
+                            string $data,
+                            SymmetricKey $key,
+                            string $footer = ''
+                        ): string {
+                            return NonceFixer::buildUnitTestNonImplicitEncrypt(self::$protocol)->bindTo(null, self::$protocol)(
+                                $data,
+                                $key,
+                                $footer,
+                                self::$nonce
+                            );
+                        }
+                    };
+                }
 
                 $class::setNonce($nonce);
                 $class::setProtocol($protocol);

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -113,10 +113,10 @@ class ParserTest extends TestCase
         $v2token = $v2parser->parse($serialized);
 
         $builder = (Builder::getLocal($key, new Version2(), $token));
-        NonceFixer::buildSetExplicitNonce()->bindTo($builder, $builder)($nonce);
+        NonceFixer::buildSetExplicitNonce(false)->bindTo($builder, $builder)($nonce);
 
         $v2builder = (Builder::getLocal($v2key, new Version2(), $v2token));
-        NonceFixer::buildSetExplicitNonce()->bindTo($v2builder, $v2builder)($nonce);
+        NonceFixer::buildSetExplicitNonce(false)->bindTo($v2builder, $v2builder)($nonce);
 
         $this->assertSame(
             '2039-01-01T00:00:00+00:00',


### PR DESCRIPTION
This seems to have been added to aid unit testing though a generic protocol.

Given the known expected behaviour for "implicit", IMO allowing this param to be specified (but ignored) seems like a fairly dangerous footgun. For example, a user who has recently learnt about PASETO in terms of v3 and v4 may specify this parameter during the verification stage, expecting that it will be validated against the string they specified during encryption/signing. Possibly unbeknownst to them, this parameter will be ignored during both production and verification
of a PASETO in v1 and v2 modes.

An alternative to these changes is to throw an exception if implicit is ever specified for v1 or v2.
I have chosen to gate this param though an interface extension because it seems clearer to catch this through static analysis than at runtime.

I've also added a check to throw if the user attempts to set or read an implicit assertion with the `Builder` (since the exact protocol is specified upon `Builder` construction, so we know if that is a sane thing to be doing or not).