### PR TITLE
Fix IdentifiedBy to check jti claim

### DIFF
--- a/src/Rules/IdentifiedBy.php
+++ b/src/Rules/IdentifiedBy.php
@@ -47,7 +47,7 @@ class IdentifiedBy implements ValidationRuleInterface
     public function isValid(JsonToken $token): bool
     {
         try {
-            $identifier = $token->getIssuer();
+            $identifier = $token->getJti();
             if (!hash_equals($this->identifier, $identifier)) {
                 $this->failure = 'This token was expected to be identified by ' .
                     $this->identifier . ', but it was identified by ' .


### PR DESCRIPTION
Currently the `IdentifiedBy` validator is checking `iss` and not the `jti` claim.

Security implications, but very unlikely to lead to an issue in practice. Only if an implementation somehow deploys code not noticing this check fails for valid tokens (i.e. `iss` and `jti` are the same or some other strange logic that causes `jti` to only be sometimes checked).