### PR TITLE
Update docblocks to allow mixed-value claims

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -298,7 +298,7 @@ class Builder extends PasetoBase
      * Set a claim to an arbitrary value.
      *
      * @param string $claim
-     * @param string $value
+     * @param mixed $value
      *
      * @return self
      */
@@ -423,7 +423,7 @@ class Builder extends PasetoBase
     /**
      * Set an array of claims in one go.
      *
-     * @param array<string, string> $claims
+     * @param array<string, mixed> $claims
      * @return self
      */
     public function setClaims(array $claims): self
@@ -695,7 +695,7 @@ class Builder extends PasetoBase
      * Return a new Builder instance with a changed claim.
      *
      * @param string $claim
-     * @param string $value
+     * @param mixed $value
      * @return self
      */
     public function with(string $claim, $value): self
@@ -720,7 +720,7 @@ class Builder extends PasetoBase
     /**
      * Return a new Builder instance with an array of changed claims.
      *
-     * @param array<string, string> $claims
+     * @param array<string, mixed> $claims
      * @return self
      */
     public function withClaims(array $claims): self

--- a/src/JsonToken.php
+++ b/src/JsonToken.php
@@ -26,7 +26,7 @@ class JsonToken
 {
     use RegisteredClaims;
 
-    /** @var array<string, string> */
+    /** @var array<string, mixed> */
     protected $claims = [];
 
     /** @var string $footer */
@@ -191,7 +191,7 @@ class JsonToken
      * Set a claim to an arbitrary value.
      *
      * @param string $claim
-     * @param string $value
+     * @param mixed $value
      * @return self
      */
     public function set(string $claim, $value): self
@@ -215,7 +215,7 @@ class JsonToken
     /**
      * Set an array of claims in one go.
      *
-     * @param array<string, string> $claims
+     * @param array<string, mixed> $claims
      * @return self
      */
     public function setClaims(array $claims): self
@@ -340,7 +340,7 @@ class JsonToken
      * Return a new JsonToken instance with a changed claim.
      *
      * @param string $claim
-     * @param string $value
+     * @param mixed $value
      * @return self
      */
     public function with(string $claim, $value): self
@@ -362,7 +362,7 @@ class JsonToken
     /**
      * Return a new JsonToken instance with an array of changed claims.
      *
-     * @param array<string, string> $claims
+     * @param array<string, mixed> $claims
      * @return self
      */
     public function withClaims(array $claims): self

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -451,7 +451,7 @@ class Parser extends PasetoBase
         // Throw if the claims were invalid:
         $this->throwIfClaimsJsonInvalid($decoded);
 
-        /** @var array<string, string>|bool $claims */
+        /** @var array<string, mixed>|bool $claims */
         $claims = json_decode($decoded, true, ($this->maxClaimDepth ?? 512));
         if (!is_array($claims)) {
             throw new EncodingException(


### PR DESCRIPTION
Fixes https://github.com/paragonie/paseto/issues/150

`mixed` typehints for `$value` arguments haven't been added
intentionally, as that would bump the minimum supported PHP version to
8.0.