### PR TITLE
Error if symmetric key length is incorrect

### DIFF
--- a/src/Keys/SymmetricKey.php
+++ b/src/Keys/SymmetricKey.php
@@ -39,13 +39,31 @@ class SymmetricKey implements ReceivingKey, SendingKey
      *
      * @param string $keyMaterial
      * @param ProtocolInterface|null $protocol
+     *
+     * @throws PasetoException
      */
     public function __construct(
         string $keyMaterial,
         ProtocolInterface $protocol = null
     ) {
-        $this->key = $keyMaterial;
         $this->protocol = $protocol ?? new Version4;
+
+        switch ($this->protocol::header()) {
+            case 'v3':
+                if (strlen($keyMaterial) !== 32) {
+                    throw new PasetoException("Invalid key length");
+                }
+                break;
+            case 'v4':
+                if (strlen($keyMaterial) !== 32) {
+                    throw new PasetoException("Invalid key length");
+                }
+                break;
+            default:
+                throw new InvalidVersionException("Unsupported version", ExceptionCode::BAD_VERSION);
+        }
+
+        $this->key = $keyMaterial;
     }
 
     /**

--- a/src/Keys/SymmetricKey.php
+++ b/src/Keys/SymmetricKey.php
@@ -48,14 +48,14 @@ class SymmetricKey implements ReceivingKey, SendingKey
     ) {
         $this->protocol = $protocol ?? new Version4;
 
-        switch ($this->protocol::header()) {
-            case 'v3':
-                if (strlen($keyMaterial) !== 32) {
+        switch ($this->protocol::class) {
+            case Version3::class:
+                if (strlen($keyMaterial) !== Version3::SYMMETRIC_KEY_BYTES) {
                     throw new PasetoException("Invalid key length");
                 }
                 break;
-            case 'v4':
-                if (strlen($keyMaterial) !== 32) {
+            case Version4::class:
+                if (strlen($keyMaterial) !== Version4::SYMMETRIC_KEY_BYTES) {
                     throw new PasetoException("Invalid key length");
                 }
                 break;

--- a/tests/KeyTest.php
+++ b/tests/KeyTest.php
@@ -7,7 +7,11 @@ use ParagonIE\Paseto\Keys\{
     AsymmetricSecretKey
 };
 use ParagonIE\ConstantTime\Binary;
-use ParagonIE\Paseto\Exception\SecurityException;
+use ParagonIE\Paseto\Exception\{
+    PasetoException,
+    SecurityException,
+};
+use ParagonIE\Paseto\Keys\Version4\SymmetricKey;
 use ParagonIE\Paseto\Util;
 use ParagonIE\Paseto\Protocol\{
     Version3,
@@ -136,5 +140,29 @@ class KeyTest extends TestCase
 
         $this->expectException(SecurityException::class);
         (new AsymmetricSecretKey($bad, new Version4()))->assertSecretKeyValid();
+    }
+
+    public function testShortV3SymmetricKey()
+    {
+        $this->expectException(PasetoException::class);
+        new SymmetricKey(random_bytes(31), new Version3());
+    }
+
+    public function testShortV4SymmetricKey()
+    {
+        $this->expectException(PasetoException::class);
+        new SymmetricKey(random_bytes(31), new Version4());
+    }
+
+    public function testLongV3SymmetricKey()
+    {
+        $this->expectException(PasetoException::class);
+        new SymmetricKey(random_bytes(33), new Version3());
+    }
+
+    public function testLongV4SymmetricKey()
+    {
+        $this->expectException(PasetoException::class);
+        new SymmetricKey(random_bytes(33), new Version4());
     }
 }


### PR DESCRIPTION
It is not strictly an encoding check, but in most cases passing in the wrong encoding will result in the wrong length. Probably it would be helpful to catch this type of error early. 

Fixes #160 