### PR TITLE
Simple `has` method since `get` throws Exception

### DIFF
--- a/src/JsonToken.php
+++ b/src/JsonToken.php
@@ -188,6 +188,17 @@ class JsonToken
     }
 
     /**
+     * Checks to see if an arbitrary claim exists.
+     *
+     * @param string $claim
+     * @return bool
+     */
+    public function has(string $claim): bool
+    {
+        return array_key_exists($claim, $this->claims);
+    }
+    
+    /**
      * Set a claim to an arbitrary value.
      *
      * @param string $claim


### PR DESCRIPTION
Have a simple way to check if there is a claim before attempting to get, since an Exception is thrown.