### PR TITLE
Move all encoding and decoding of asymmetric keys to specific version files

### DIFF
--- a/src/Keys/AsymmetricPublicKey.php
+++ b/src/Keys/AsymmetricPublicKey.php
@@ -114,22 +114,17 @@ abstract class AsymmetricPublicKey implements ReceivingKey
      * @param string $keyMaterial
      * @return self
      *
-     * @throws PasetoException
      * @throws Exception
      */
     public static function newVersionKey(string $keyMaterial, ProtocolInterface $protocol = null): self
     {
         $protocol = $protocol ?? new Version4();
 
-        if ($protocol instanceof Version3) {
+        if (hash_equals($protocol::header(), Version3::HEADER)) {
             return new V3AsymmetricPublicKey($keyMaterial);
         }
 
-        if ($protocol instanceof Version4) {
-            return new V4AsymmetricPublicKey($keyMaterial);
-        }
-
-        throw new PasetoException("Unknown version");
+        return new V4AsymmetricPublicKey($keyMaterial);
     }
 
     /**

--- a/src/Keys/AsymmetricSecretKey.php
+++ b/src/Keys/AsymmetricSecretKey.php
@@ -176,10 +176,9 @@ abstract class AsymmetricSecretKey implements SendingKey
      * @param string $keyMaterial
      * @return self
      *
-     * @throws PasetoException
      * @throws Exception
      */
-    public static function create(string $keyMaterial, ProtocolInterface $protocol = null): self
+    public static function newVersionKey(string $keyMaterial, ProtocolInterface $protocol = null): self
     {
         $protocol = $protocol ?? new Version4();
 

--- a/src/Keys/Version3/AsymmetricPublicKey.php
+++ b/src/Keys/Version3/AsymmetricPublicKey.php
@@ -2,10 +2,17 @@
 declare(strict_types=1);
 namespace ParagonIE\Paseto\Keys\Version3;
 
+use FG\ASN1\Exception\ParserException;
+use ParagonIE\ConstantTime\Base64UrlSafe;
+use ParagonIE\ConstantTime\Binary;
+use ParagonIE\ConstantTime\Hex;
+use ParagonIE\EasyECC\ECDSA\PublicKey;
+use ParagonIE\Paseto\Exception\PasetoException;
 use ParagonIE\Paseto\Keys\AsymmetricPublicKey as BasePublicKey;
 use ParagonIE\Paseto\Protocol\Version3;
 use ParagonIE\Paseto\ProtocolInterface;
 use Exception;
+use ParagonIE\Paseto\Util;
 use TypeError;
 
 /**
@@ -25,6 +32,70 @@ class AsymmetricPublicKey extends BasePublicKey
      */
     public function __construct(string $keyData, ProtocolInterface $protocol = null)
     {
+        $len = Binary::safeStrlen($keyData);
+        if ($len === 98) {
+            $keyData = Version3::getPublicKeyPem($keyData);
+        } elseif ($len === 49) {
+            $keyData = Version3::getPublicKeyPem(Hex::encode($keyData));
+        }
+
         parent::__construct($keyData, new Version3());
+    }
+
+    public function encode(): string
+    {
+        if (Binary::safeStrlen($this->key) === 49) {
+            Base64UrlSafe::encodeUnpadded($this->key);
+        } elseif (Binary::safeStrlen($this->key) === 98) {
+            Base64UrlSafe::encodeUnpadded(Hex::decode($this->key));
+        }
+        try {
+            return Base64UrlSafe::encodeUnpadded(
+                Hex::decode(
+                    Version3::getPublicKeyCompressed($this->key)
+                )
+            );
+        } catch (ParserException $ex) {
+            throw new PasetoException("ASN.1 Parser Exception", 0, $ex);
+        }
+    }
+
+    public function encodePem(): string
+    {
+        if (Binary::safeStrlen($this->key) > 49) {
+            return $this->key;
+        }
+        return Util::dos2unix(
+            PublicKey::fromString($this->key, 'P384')
+                ->exportPem()
+        );
+    }
+
+    public static function fromEncodedString(string $encoded, ProtocolInterface $version = null): self
+    {
+        $decodeString = Base64UrlSafe::decode($encoded);
+        $length = Binary::safeStrlen($encoded);
+        if ($length === 98) {
+            $decoded = Version3::getPublicKeyPem($decodeString);
+        } elseif ($length === 49) {
+            $decoded = Version3::getPublicKeyPem(Hex::encode($decodeString));
+        } else {
+            $decoded = $decodeString;
+        }
+
+        return new self($decoded, $version);
+    }
+
+    public function toHexString(): string
+    {
+        if (Binary::safeStrlen($this->key) === 98) {
+            return $this->key;
+        }
+
+        if (Binary::safeStrlen($this->key) !== 49) {
+            return Version3::getPublicKeyCompressed($this->key);
+        }
+
+        return Hex::encode($this->key);
     }
 }

--- a/src/Keys/Version4/AsymmetricPublicKey.php
+++ b/src/Keys/Version4/AsymmetricPublicKey.php
@@ -2,10 +2,17 @@
 declare(strict_types=1);
 namespace ParagonIE\Paseto\Keys\Version4;
 
+use ParagonIE\ConstantTime\Base64;
+use ParagonIE\ConstantTime\Base64UrlSafe;
+use ParagonIE\ConstantTime\Binary;
+use ParagonIE\ConstantTime\Hex;
+use ParagonIE\Paseto\Exception\ExceptionCode;
+use ParagonIE\Paseto\Exception\PasetoException;
 use ParagonIE\Paseto\Keys\AsymmetricPublicKey as BasePublicKey;
 use ParagonIE\Paseto\Protocol\Version4;
 use ParagonIE\Paseto\ProtocolInterface;
 use Exception;
+use ParagonIE\Paseto\Util;
 use TypeError;
 
 /**
@@ -25,6 +32,43 @@ class AsymmetricPublicKey extends BasePublicKey
      */
     public function __construct(string $keyData, ProtocolInterface $protocol = null)
     {
+        $len = Binary::safeStrlen($keyData);
+        if ($len === SODIUM_CRYPTO_SIGN_PUBLICKEYBYTES << 1) {
+            // Try hex-decoding
+            $keyData = Hex::decode($keyData);
+        } else if ($len !== SODIUM_CRYPTO_SIGN_PUBLICKEYBYTES) {
+            throw new PasetoException(
+                'Public keys must be 32 bytes long; ' . $len . ' given.',
+                ExceptionCode::UNSPECIFIED_CRYPTOGRAPHIC_ERROR
+            );
+        }
+
         parent::__construct($keyData, new Version4());
+    }
+
+    public function encode(): string
+    {
+        return Base64UrlSafe::encodeUnpadded($this->key);
+    }
+
+    public function encodePem(): string
+    {
+        $encoded = Base64::encode(
+            Hex::decode('302a300506032b6570032100') . $this->raw()
+        );
+        return "-----BEGIN PUBLIC KEY-----\n" .
+            Util::dos2unix(chunk_split($encoded, 64)).
+            "-----END PUBLIC KEY-----";
+    }
+
+    public static function fromEncodedString(string $encoded, ProtocolInterface $version = null): self
+    {
+        $decoded = Base64UrlSafe::decode($encoded);
+        return new self($decoded, $version);
+    }
+
+    public function toHexString(): string
+    {
+        return Hex::encode($this->key);
     }
 }

--- a/src/Keys/Version4/AsymmetricSecretKey.php
+++ b/src/Keys/Version4/AsymmetricSecretKey.php
@@ -2,10 +2,17 @@
 declare(strict_types=1);
 namespace ParagonIE\Paseto\Keys\Version4;
 
+use ParagonIE\ConstantTime\Base64;
+use ParagonIE\ConstantTime\Base64UrlSafe;
+use ParagonIE\ConstantTime\Binary;
+use ParagonIE\ConstantTime\Hex;
+use ParagonIE\Paseto\Exception\ExceptionCode;
+use ParagonIE\Paseto\Exception\PasetoException;
 use ParagonIE\Paseto\Keys\AsymmetricSecretKey as BaseSecretKey;
 use ParagonIE\Paseto\Protocol\Version4;
 use ParagonIE\Paseto\ProtocolInterface;
 use Exception;
+use ParagonIE\Paseto\Util;
 use TypeError;
 
 /**
@@ -25,6 +32,59 @@ class AsymmetricSecretKey extends BaseSecretKey
      */
     public function __construct(string $keyData, ProtocolInterface $protocol = null)
     {
+        $len = Binary::safeStrlen($keyData);
+        if ($len === SODIUM_CRYPTO_SIGN_KEYPAIRBYTES) {
+            $keyData = Binary::safeSubstr($keyData, 0, 64);
+        } elseif ($len !== SODIUM_CRYPTO_SIGN_SECRETKEYBYTES) {
+            if ($len !== SODIUM_CRYPTO_SIGN_SEEDBYTES) {
+                throw new PasetoException(
+                    'Secret keys must be 32 or 64 bytes long; ' . $len . ' given.',
+                    ExceptionCode::UNSPECIFIED_CRYPTOGRAPHIC_ERROR
+                );
+            }
+            $keypair = sodium_crypto_sign_seed_keypair($keyData);
+            $keyData = Binary::safeSubstr($keypair, 0, 64);
+        }
+
         parent::__construct($keyData, new Version4());
+    }
+
+    public static function generate(ProtocolInterface $protocol = null): self
+    {
+        return new self(
+            sodium_crypto_sign_secretkey(
+                sodium_crypto_sign_keypair()
+            ),
+            $protocol
+        );
+    }
+
+    public function encode(): string
+    {
+        return Base64UrlSafe::encodeUnpadded($this->key);
+    }
+
+    public function encodePem(): string
+    {
+        $encoded = Base64::encode(
+            Hex::decode('302e020100300506032b657004220420') . $this->raw()
+        );
+        return "-----BEGIN EC PRIVATE KEY-----\n" .
+            Util::dos2unix(chunk_split($encoded, 64)).
+            "-----END EC PRIVATE KEY-----";
+    }
+
+    public static function fromEncodedString(string $encoded, ProtocolInterface $version = null): self
+    {
+        $decoded = Base64UrlSafe::decodeNoPadding($encoded);
+        return new self($decoded, $version);
+    }
+
+    public function getPublicKey(): AsymmetricPublicKey
+    {
+        return new AsymmetricPublicKey(
+            sodium_crypto_sign_publickey_from_secretkey($this->key),
+            $this->protocol
+        );
     }
 }

--- a/tests/JsonTokenTest.php
+++ b/tests/JsonTokenTest.php
@@ -61,7 +61,7 @@ class JsonTokenTest extends TestCase
 
         // Now let's switch gears to asymmetric crypto:
         $builder->setPurpose(Purpose::public())
-                ->setKey(AsymmetricSecretKey::create('YELLOW SUBMARINE, BLACK WIZARDRY'), true);
+                ->setKey(AsymmetricSecretKey::newVersionKey('YELLOW SUBMARINE, BLACK WIZARDRY'), true);
         $this->assertSame(
             'v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9_LCndxFrGmFDZbUAgixuWRPZv7J67DA6AT69KfJU2APR8J-APE1RxlKrdFyumd2h_GjcU4tdNgHlgZpuKf3BCQ',
             (string) $builder,

--- a/tests/JsonTokenTest.php
+++ b/tests/JsonTokenTest.php
@@ -61,7 +61,7 @@ class JsonTokenTest extends TestCase
 
         // Now let's switch gears to asymmetric crypto:
         $builder->setPurpose(Purpose::public())
-                ->setKey(new AsymmetricSecretKey('YELLOW SUBMARINE, BLACK WIZARDRY'), true);
+                ->setKey(AsymmetricSecretKey::create('YELLOW SUBMARINE, BLACK WIZARDRY'), true);
         $this->assertSame(
             'v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9_LCndxFrGmFDZbUAgixuWRPZv7J67DA6AT69KfJU2APR8J-APE1RxlKrdFyumd2h_GjcU4tdNgHlgZpuKf3BCQ',
             (string) $builder,

--- a/tests/KeyTest.php
+++ b/tests/KeyTest.php
@@ -138,11 +138,11 @@ class KeyTest extends TestCase
         $good2 = Binary::safeSubstr($keypair2, 0, 64);
         $bad = Binary::safeSubstr($keypair1, 0, 32) . Binary::safeSubstr($keypair2, 32, 32);
 
-        (new AsymmetricSecretKey($good1, new Version4()))->assertSecretKeyValid();
-        (new AsymmetricSecretKey($good2, new Version4()))->assertSecretKeyValid();
+        (AsymmetricSecretKey::create($good1, new Version4()))->assertSecretKeyValid();
+        (AsymmetricSecretKey::create($good2, new Version4()))->assertSecretKeyValid();
 
         $this->expectException(SecurityException::class);
-        (new AsymmetricSecretKey($bad, new Version4()))->assertSecretKeyValid();
+        (AsymmetricSecretKey::create($bad, new Version4()))->assertSecretKeyValid();
     }
 
     public function testShortV3SymmetricKey()

--- a/tests/KeyTest.php
+++ b/tests/KeyTest.php
@@ -138,11 +138,11 @@ class KeyTest extends TestCase
         $good2 = Binary::safeSubstr($keypair2, 0, 64);
         $bad = Binary::safeSubstr($keypair1, 0, 32) . Binary::safeSubstr($keypair2, 32, 32);
 
-        (AsymmetricSecretKey::create($good1, new Version4()))->assertSecretKeyValid();
-        (AsymmetricSecretKey::create($good2, new Version4()))->assertSecretKeyValid();
+        (AsymmetricSecretKey::newVersionKey($good1, new Version4()))->assertSecretKeyValid();
+        (AsymmetricSecretKey::newVersionKey($good2, new Version4()))->assertSecretKeyValid();
 
         $this->expectException(SecurityException::class);
-        (AsymmetricSecretKey::create($bad, new Version4()))->assertSecretKeyValid();
+        (AsymmetricSecretKey::newVersionKey($bad, new Version4()))->assertSecretKeyValid();
     }
 
     public function testShortV3SymmetricKey()

--- a/tests/KnownAnswerTest.php
+++ b/tests/KnownAnswerTest.php
@@ -150,7 +150,7 @@ class KnownAnswerTest extends TestCase
         bool $public = false
     ): AsymmetricPublicKey|SymmetricKey {
         if ($public) {
-            return new AsymmetricPublicKey($key, $protocol);
+            return AsymmetricPublicKey::newVersionKey($key, $protocol);
         }
         return new SymmetricKey(Hex::decode($key), $protocol);
     }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -50,7 +50,7 @@ class ParserTest extends TestCase
     public function testTypeSafety()
     {
         $keypair = sodium_crypto_sign_keypair();
-        $publicKey = new AsymmetricPublicKey(sodium_crypto_sign_publickey($keypair), new Version4());
+        $publicKey = AsymmetricPublicKey::newVersionKey(sodium_crypto_sign_publickey($keypair), new Version4());
 
         // Let's encrypt a bad oken using the Ed25519 public key
         $badKey = new SymmetricKey(sodium_crypto_sign_publickey($keypair), new Version4());
@@ -159,7 +159,7 @@ class ParserTest extends TestCase
         $V4builder = (Builder::getLocal($V4key, new Version4(), $V4token));
         // Switch to asymmetric-key crypto:
         $builder->setPurpose(Purpose::public())
-                ->setKey(new AsymmetricSecretKey('YELLOW SUBMARINE, BLACK WIZARDRY', new Version4()), true);
+                ->setKey(AsymmetricSecretKey::create('YELLOW SUBMARINE, BLACK WIZARDRY', new Version4()), true);
         $V4builder->setPurpose(Purpose::public())
                 ->setKey(new V4AsymmetricSecretKey('YELLOW SUBMARINE, BLACK WIZARDRY'), true);
         $this->assertSame(
@@ -393,7 +393,7 @@ class ParserTest extends TestCase
      */
     public function testTokenSignVerify(): void
     {
-        $secretKey = new AsymmetricSecretKey('YELLOW SUBMARINE, BLACK WIZARDRY', new Version4());
+        $secretKey = AsymmetricSecretKey::create('YELLOW SUBMARINE, BLACK WIZARDRY', new Version4());
         $publicKey = $secretKey->getPublicKey();
         $parser = new Parser(ProtocolCollection::default(), Purpose::public(), $publicKey);
         $tainted = 'v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9_LCndxFrGmFDZbUAgixuWRPZv7J67DA6AT69KfJU2APR8J-APE1RxlKrdFyumd2h_GjcU4tdNgHlgZpuKf3BCQ';

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -159,7 +159,7 @@ class ParserTest extends TestCase
         $V4builder = (Builder::getLocal($V4key, new Version4(), $V4token));
         // Switch to asymmetric-key crypto:
         $builder->setPurpose(Purpose::public())
-                ->setKey(AsymmetricSecretKey::create('YELLOW SUBMARINE, BLACK WIZARDRY', new Version4()), true);
+                ->setKey(AsymmetricSecretKey::newVersionKey('YELLOW SUBMARINE, BLACK WIZARDRY', new Version4()), true);
         $V4builder->setPurpose(Purpose::public())
                 ->setKey(new V4AsymmetricSecretKey('YELLOW SUBMARINE, BLACK WIZARDRY'), true);
         $this->assertSame(
@@ -393,7 +393,7 @@ class ParserTest extends TestCase
      */
     public function testTokenSignVerify(): void
     {
-        $secretKey = AsymmetricSecretKey::create('YELLOW SUBMARINE, BLACK WIZARDRY', new Version4());
+        $secretKey = AsymmetricSecretKey::newVersionKey('YELLOW SUBMARINE, BLACK WIZARDRY', new Version4());
         $publicKey = $secretKey->getPublicKey();
         $parser = new Parser(ProtocolCollection::default(), Purpose::public(), $publicKey);
         $tainted = 'v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAzOS0wMS0wMVQwMDowMDowMCswMDowMCJ9_LCndxFrGmFDZbUAgixuWRPZv7J67DA6AT69KfJU2APR8J-APE1RxlKrdFyumd2h_GjcU4tdNgHlgZpuKf3BCQ';


### PR DESCRIPTION
In order to prevent version specific conditions in many locations, I choose to make `Keys\AsymmetricSecretKey` and `Keys\AsymmetricPublicKey` abstract classes. This forces all instances to be of a specific version. This is a BC-break though. With this PR `new Keys\AsymmetricSecretKey()` and `new Keys\AsymmetricPublicKey` are not possible anymore. I doubt if this BC-break makes a huge impact on the users of the library. Who would have instantiated these keys using its constructor directly? But still, it is a BC-break.

If you insist in fixing this without any BC breaks, I can make that work too, but I doubt if that makes the code more maintainable. And the goal of this PR is to make the code more maintainable. With this PR you can clearly see if there are anymore bugs between encoding and decoding of the specific versions. And there are. A question that arises is what to do with `new Keys\SymmetricKey()`? It would be consistent to make that abstract too. I would definitely prefer to go for that.

If this would be merged, I can make tests for all the encoding and decoding and add `importPem` method to both versions.