### PR TITLE
PHP 8.4 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-latest']
-        php-versions: ['8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.3', '8.4']
         phpunit-versions: ['latest']
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea
+/.phpunit.result.cache
 /composer.lock
 /vendor

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^9",
-    "vimeo/psalm": "^4|^5"
+    "vimeo/psalm": "dev-master"
   },
   "scripts": {
     "full-test": [

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "paragonie/sodium_compat": "^1|^2"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9",
+    "phpunit/phpunit": "^11",
     "vimeo/psalm": "dev-master"
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "paragonie/sodium_compat": "^1|^2"
   },
   "require-dev": {
-    "phpunit/phpunit": "^11",
+    "phpunit/phpunit": "^10",
     "vimeo/psalm": "dev-master"
   },
   "scripts": {

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -42,7 +42,7 @@ the fact that the header is always authenticated, and the suffix exists in the h
 
 ## Specifying Version and Purpose
 
-In PASETO, the Version and Purpose are a part of the cryptographic material's identity 
+In PASETO, the Version and Purpose are a part of the cryptographic material's identity
 (not just its raw bytes). That means that each key can be used with at most one of the
 8 combinations of version and purpose.
 
@@ -65,7 +65,7 @@ PASETO tokens typically have this format:
 
     [version].[purpose].[data]
 
-However, it's possible to append optional data to the end of a PASETO, which will also be 
+However, it's possible to append optional data to the end of a PASETO, which will also be
 authenticated. This yields the following format:
 
     [version].[purpose].[data].[footer]
@@ -98,7 +98,7 @@ use ParagonIE\Paseto\Keys\Base\SymmetricKey;use ParagonIE\Paseto\Parser;use Para
 /** @var SymmetricKey $key */
 $parser = Parser::getLocal($key)
     ->addRule(
-        (new FooterJSON())
+        new FooterJSON
             ->setMaxLength(1024) // Maximum length of JSON payload in footer
             ->setMaxKeys(16)     // Maximum number of object keys
             ->setMaxDepth(3)     // Recursive depth to JSON structure
@@ -117,7 +117,8 @@ You can set the implicit assertions in the Builder...
 
 ```php
 <?php
-use ParagonIE\Paseto\Builder;use ParagonIE\Paseto\Keys\Base\SymmetricKey;
+use ParagonIE\Paseto\Builder;
+use ParagonIE\Paseto\Keys\Base\SymmetricKey;
 
 /** @var SymmetricKey $key */
 $builder = Builder::getLocal($key)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,9 +2,9 @@
 
 If you're not already familiar with PASETO, you can learn more about its features
 [here](Features.md). If you were using an older version of PASETO, the
-[migration guide](Migration.md) is worth a read. 
+[migration guide](Migration.md) is worth a read.
 
-Most of the supporting documentation has been moved to the 
+Most of the supporting documentation has been moved to the
 [PASETO specification](https://github.com/paseto-standard/paseto-spec) repository.
 
 ## How to use the PHP library
@@ -69,7 +69,7 @@ use ParagonIE\Paseto\Keys\Base\SymmetricKey;use ParagonIE\Paseto\Protocol\Versio
  * We assume the same key $sharedKey was used from above.
  * @var SymmetricKey $sharedKey
  */
- 
+
 $token = Version4::sign('some arbitrary data', $sharedKey);
 ```
 
@@ -129,7 +129,7 @@ $parser = Parser::getLocal($sharedKey, ProtocolCollection::v4())
     ->addRule(new IssuedBy('issuer defined during creation'));
 
 // This is the same as:
-$parser = (new Parser())
+$parser = new Parser
     ->setKey($sharedKey)
     // Adding rules to be checked against the token
     ->addRule(new ValidAt)
@@ -168,13 +168,13 @@ use ParagonIE\Paseto\Keys\Base\AsymmetricPublicKey;use ParagonIE\Paseto\Keys\Bas
  * @var AsymmetricPublicKey $pk1
  * @var AsymmetricPublicKey $pk2
  */
-$keyring = (new ReceivingKeyRing())
+$keyring = new ReceivingKeyRing
     ->setVersion(new Version4)
     ->setPurpose(Purpose::public())
     ->addKey('gandalf0', $pk1)
     ->addKey('legolas1', $pk2);
 
-$otherKeyring = (new ReceivingKeyRing())
+$otherKeyring = new ReceivingKeyRing
     ->setVersion(new Version4)
     ->setPurpose(Purpose::local())
     ->addKey('boromir2', $localKey);

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -50,9 +50,9 @@ class Builder extends PasetoBase
      * @throws PasetoException
      */
     public function __construct(
-        JsonToken $baseToken = null,
-        ProtocolInterface $protocol = null,
-        SendingKey $key = null
+        ?JsonToken $baseToken = null,
+        ?ProtocolInterface $protocol = null,
+        ?SendingKey $key = null
     ) {
         if (!$baseToken) {
             $baseToken = new JsonToken();
@@ -176,8 +176,8 @@ class Builder extends PasetoBase
      */
     public static function getLocal(
         SymmetricKey $key,
-        ProtocolInterface $version = null,
-        JsonToken $baseToken = null
+        ?ProtocolInterface $version = null,
+        ?JsonToken $baseToken = null
     ): self {
         if (!$version) {
             $version = $key->getProtocol();
@@ -202,8 +202,8 @@ class Builder extends PasetoBase
      */
     public static function getLocalWithKeyRing(
         SendingKeyRing    $key,
-        ProtocolInterface $version = null,
-        JsonToken         $baseToken = null
+        ?ProtocolInterface $version = null,
+        ?JsonToken         $baseToken = null
     ): self {
         if (!$version) {
             $version = $key->getProtocol();
@@ -228,8 +228,8 @@ class Builder extends PasetoBase
      */
     public static function getPublic(
         AsymmetricSecretKey $key,
-        ProtocolInterface $version = null,
-        JsonToken $baseToken = null
+        ?ProtocolInterface $version = null,
+        ?JsonToken $baseToken = null
     ): self {
         if (!$version) {
             $version = $key->getProtocol();
@@ -254,8 +254,8 @@ class Builder extends PasetoBase
      */
     public static function getPublicWithKeyRing(
         SendingKeyRing    $key,
-        ProtocolInterface $version = null,
-        JsonToken         $baseToken = null
+        ?ProtocolInterface $version = null,
+        ?JsonToken         $baseToken = null
     ): self {
         if (!$version) {
             $version = $key->getProtocol();
@@ -308,7 +308,7 @@ class Builder extends PasetoBase
      * @param DateTimeInterface|null $time
      * @return self
      */
-    public function setExpiration(DateTimeInterface $time = null): self
+    public function setExpiration(?DateTimeInterface $time = null): self
     {
         if (!$time) {
             $time = new DateTime('NOW');
@@ -348,7 +348,7 @@ class Builder extends PasetoBase
      * @param DateTimeInterface|null $time
      * @return self
      */
-    public function setIssuedAt(DateTimeInterface $time = null): self
+    public function setIssuedAt(?DateTimeInterface $time = null): self
     {
         if (!$time) {
             $time = new DateTime('NOW');
@@ -384,7 +384,7 @@ class Builder extends PasetoBase
      * @param DateTimeInterface|null $time
      * @return self
      */
-    public function setNotBefore(DateTimeInterface $time = null): self
+    public function setNotBefore(?DateTimeInterface $time = null): self
     {
         if (!$time) {
             $time = new DateTime('NOW');
@@ -569,7 +569,7 @@ class Builder extends PasetoBase
      *
      * @return self
      */
-    public function setVersion(ProtocolInterface $version = null): self
+    public function setVersion(?ProtocolInterface $version = null): self
     {
         if (!$version) {
             $version = new Version4();
@@ -716,7 +716,7 @@ class Builder extends PasetoBase
      * @param DateTimeInterface|null $time
      * @return self
      */
-    public function withExpiration(DateTimeInterface $time = null): self
+    public function withExpiration(?DateTimeInterface $time = null): self
     {
         return (clone $this)->setExpiration($time);
     }
@@ -765,7 +765,7 @@ class Builder extends PasetoBase
      * @param DateTimeInterface|null $time
      * @return self
      */
-    public function withIssuedAt(DateTimeInterface $time = null): self
+    public function withIssuedAt(?DateTimeInterface $time = null): self
     {
         return (clone $this)->setIssuedAt($time);
     }
@@ -798,7 +798,7 @@ class Builder extends PasetoBase
      * @param DateTimeInterface|null $time
      * @return self
      */
-    public function withNotBefore(DateTimeInterface $time = null): self
+    public function withNotBefore(?DateTimeInterface $time = null): self
     {
         return (clone $this)->setNotBefore($time);
     }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -615,6 +615,7 @@ class Builder extends PasetoBase
                 ->format(DateTime::ATOM);
         }
         $claims = json_encode($claimsArray, JSON_FORCE_OBJECT);
+        assert(is_string($claims));
         $protocol = $this->version;
         ProtocolCollection::throwIfUnsupported($protocol);
 

--- a/src/Exception/PasetoException.php
+++ b/src/Exception/PasetoException.php
@@ -7,9 +7,10 @@ use Throwable;
 
 /**
  * Class PasetoException
+ * 
  * @package ParagonIE\Paseto\Exception
  */
-class PasetoException extends \Exception
+class PasetoException extends Exception
 {
     /**
      * @param string $message

--- a/src/Exception/PasetoException.php
+++ b/src/Exception/PasetoException.php
@@ -9,14 +9,14 @@ use Throwable;
  * Class PasetoException
  * @package ParagonIE\Paseto\Exception
  */
-class PasetoException extends Exception
+class PasetoException extends \Exception
 {
     /**
      * @param string $message
      * @param int $code
      * @param Throwable|null $previous
      */
-    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    public function __construct($message = "", $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $this->setHelpfulMessage(ExceptionCode::explainErrorCode($code));

--- a/src/JsonToken.php
+++ b/src/JsonToken.php
@@ -197,7 +197,7 @@ class JsonToken
     {
         return array_key_exists($claim, $this->claims);
     }
-    
+
     /**
      * Set a claim to an arbitrary value.
      *
@@ -241,7 +241,7 @@ class JsonToken
      * @param DateTimeInterface|null $time
      * @return self
      */
-    public function setExpiration(DateTimeInterface $time = null): self
+    public function setExpiration(?DateTimeInterface $time = null): self
     {
         if (!$time) {
             $time = new DateTime('NOW');
@@ -287,7 +287,7 @@ class JsonToken
      * @param DateTimeInterface|null $time
      * @return self
      */
-    public function setIssuedAt(DateTimeInterface $time = null): self
+    public function setIssuedAt(?DateTimeInterface $time = null): self
     {
         if (!$time) {
             $time = new DateTime('NOW');
@@ -326,7 +326,7 @@ class JsonToken
      * @param DateTimeInterface|null $time
      * @return self
      */
-    public function setNotBefore(DateTimeInterface $time = null): self
+    public function setNotBefore(?DateTimeInterface $time = null): self
     {
         if (!$time) {
             $time = new DateTime('NOW');
@@ -387,7 +387,7 @@ class JsonToken
      * @param DateTimeInterface|null $time
      * @return self
      */
-    public function withExpiration(DateTimeInterface $time = null): self
+    public function withExpiration(?DateTimeInterface $time = null): self
     {
         return (clone $this)->setExpiration($time);
     }
@@ -422,7 +422,7 @@ class JsonToken
      * @param DateTimeInterface|null $time
      * @return self
      */
-    public function withIssuedAt(DateTimeInterface $time = null): self
+    public function withIssuedAt(?DateTimeInterface $time = null): self
     {
         return (clone $this)->setIssuedAt($time);
     }
@@ -455,7 +455,7 @@ class JsonToken
      * @param DateTimeInterface|null $time
      * @return self
      */
-    public function withNotBefore(DateTimeInterface $time = null): self
+    public function withNotBefore(?DateTimeInterface $time = null): self
     {
         return (clone $this)->setNotBefore($time);
     }

--- a/src/Keys/AsymmetricSecretKey.php
+++ b/src/Keys/AsymmetricSecretKey.php
@@ -23,7 +23,7 @@ class AsymmetricSecretKey extends BaseAsymmetricSecretKey
 {
     public function __construct(
         string $keyData,
-        ProtocolInterface $protocol = null
+        ?ProtocolInterface $protocol = null
     ) {
         if (is_null($protocol)) {
             $protocol = new Version4();

--- a/src/Keys/Base/AsymmetricPublicKey.php
+++ b/src/Keys/Base/AsymmetricPublicKey.php
@@ -117,7 +117,10 @@ abstract class AsymmetricPublicKey implements ReceivingKey
      *
      * @throws Exception
      */
-    public static function newVersionKey(string $keyMaterial, ProtocolInterface $protocol = null): self
+    public static function newVersionKey(
+        string $keyMaterial,
+        ?ProtocolInterface $protocol = null,
+    ): self
     {
         $protocol = $protocol ?? new Version4();
 
@@ -155,7 +158,10 @@ abstract class AsymmetricPublicKey implements ReceivingKey
      * @throws Exception
      * @throws TypeError
      */
-    public static function fromEncodedString(string $encoded, ProtocolInterface $version = null): self
+    public static function fromEncodedString(
+        string $encoded,
+        ?ProtocolInterface $version = null,
+    ): self
     {
         if (!$version) {
             $version = new Version4();
@@ -175,7 +181,7 @@ abstract class AsymmetricPublicKey implements ReceivingKey
      *
      * @throws Exception
      */
-    public static function importPem(string $pem, ProtocolInterface $protocol = null): self
+    public static function importPem(string $pem, ?ProtocolInterface $protocol = null): self
     {
         $protocol = $protocol ?? new Version4();
 

--- a/src/Keys/Base/AsymmetricSecretKey.php
+++ b/src/Keys/Base/AsymmetricSecretKey.php
@@ -159,7 +159,7 @@ abstract class AsymmetricSecretKey implements SendingKey
      * @throws Exception
      * @throws TypeError
      */
-    public static function generate(ProtocolInterface $protocol = null): self
+    public static function generate(?ProtocolInterface $protocol = null): self
     {
         $protocol = $protocol ?? new Version4;
         if (hash_equals($protocol::header(), Version3::HEADER)) {
@@ -178,7 +178,7 @@ abstract class AsymmetricSecretKey implements SendingKey
      *
      * @throws Exception
      */
-    public static function newVersionKey(string $keyMaterial, ProtocolInterface $protocol = null): self
+    public static function newVersionKey(string $keyMaterial, ?ProtocolInterface $protocol = null): self
     {
         $protocol = $protocol ?? new Version4();
 
@@ -216,7 +216,7 @@ abstract class AsymmetricSecretKey implements SendingKey
      * @throws Exception
      * @throws TypeError
      */
-    public static function fromEncodedString(string $encoded, ProtocolInterface $version = null): self
+    public static function fromEncodedString(string $encoded, ?ProtocolInterface $version = null): self
     {
         if ($version && hash_equals($version::header(), Version3::HEADER)) {
             return V3AsymmetricSecretKey::fromEncodedString($encoded);
@@ -232,7 +232,7 @@ abstract class AsymmetricSecretKey implements SendingKey
      *
      * @throws Exception
      */
-    public static function importPem(string $pem, ProtocolInterface $protocol = null): self
+    public static function importPem(string $pem, ?ProtocolInterface $protocol = null): self
     {
         $protocol = $protocol ?? new Version4();
 

--- a/src/Keys/Base/SymmetricKey.php
+++ b/src/Keys/Base/SymmetricKey.php
@@ -45,7 +45,7 @@ class SymmetricKey implements ReceivingKey, SendingKey
      */
     public function __construct(
         string $keyMaterial,
-        ProtocolInterface $protocol = null
+        ?ProtocolInterface $protocol = null
     ) {
         $this->protocol = $protocol ?? new Version4;
 
@@ -81,7 +81,7 @@ class SymmetricKey implements ReceivingKey, SendingKey
      *
      * @throws Exception
      */
-    public static function generate(ProtocolInterface $protocol = null): self
+    public static function generate(?ProtocolInterface $protocol = null): self
     {
         $protocol = $protocol ?? new Version4;
         $length = $protocol::getSymmetricKeyByteLength();
@@ -172,7 +172,10 @@ class SymmetricKey implements ReceivingKey, SendingKey
      * @throws TypeError
      * @throws PasetoException
      */
-    public static function fromEncodedString(string $encoded, ProtocolInterface $version = null): self
+    public static function fromEncodedString(
+        string $encoded,
+        ?ProtocolInterface $version = null,
+    ): self
     {
         $decoded = Base64UrlSafe::decodeNoPadding($encoded);
         return new self($decoded, $version);

--- a/src/Keys/Version3/AsymmetricPublicKey.php
+++ b/src/Keys/Version3/AsymmetricPublicKey.php
@@ -70,7 +70,10 @@ class AsymmetricPublicKey extends BasePublicKey
         );
     }
 
-    public static function fromEncodedString(string $encoded, ProtocolInterface $version = null): self
+    public static function fromEncodedString(
+        string $encoded,
+        ?ProtocolInterface $version = null,
+    ): self
     {
         $decodeString = Base64UrlSafe::decode($encoded);
         $length = Binary::safeStrlen($encoded);
@@ -105,7 +108,7 @@ class AsymmetricPublicKey extends BasePublicKey
      *
      * @throws Exception
      */
-    public static function importPem(string $pem, ProtocolInterface $protocol = null): self
+    public static function importPem(string $pem, ?ProtocolInterface $protocol = null): self
     {
         return new self($pem);
     }

--- a/src/Keys/Version3/AsymmetricSecretKey.php
+++ b/src/Keys/Version3/AsymmetricSecretKey.php
@@ -36,7 +36,7 @@ class AsymmetricSecretKey extends BaseSecretKey
         parent::__construct($keyData, new Version3());
     }
 
-    public static function generate(ProtocolInterface $protocol = null): self
+    public static function generate(?ProtocolInterface $protocol = null): self
     {
         return new self(
             Util::dos2unix(SecretKey::generate(Version3::CURVE)->exportPem())
@@ -64,7 +64,7 @@ class AsymmetricSecretKey extends BaseSecretKey
         return Util::dos2unix($this->key);
     }
 
-    public static function fromEncodedString(string $encoded, ProtocolInterface $version = null): self
+    public static function fromEncodedString(string $encoded, ?ProtocolInterface $version = null): self
     {
         $decoded = Base64UrlSafe::decodeNoPadding($encoded);
 
@@ -101,7 +101,7 @@ class AsymmetricSecretKey extends BaseSecretKey
         );
     }
 
-    public static function importPem(string $pem, ProtocolInterface $protocol = null): self
+    public static function importPem(string $pem, ?ProtocolInterface $protocol = null): self
     {
         return new self($pem);
     }

--- a/src/Keys/Version4/AsymmetricPublicKey.php
+++ b/src/Keys/Version4/AsymmetricPublicKey.php
@@ -88,14 +88,16 @@ class AsymmetricPublicKey extends BasePublicKey
     {
         $formattedKey = str_replace('-----BEGIN PUBLIC KEY-----', '', $pem);
         $formattedKey = str_replace('-----END PUBLIC KEY-----', '', $formattedKey);
-        if (!is_string($formattedKey)) {
-            throw new PasetoException('Invalid PEM format', ExceptionCode::UNSPECIFIED_CRYPTOGRAPHIC_ERROR);
+        if (PHP_VERSION_ID >= 80400) {
+            if (!is_string($formattedKey)) {
+                throw new PasetoException('Invalid PEM format', ExceptionCode::UNSPECIFIED_CRYPTOGRAPHIC_ERROR);
+            }
         }
 
-        $tokenizedKey = strtok($formattedKey, "\n") ?: throw new PasetoException(
-            'Invalid PEM format',
-            ExceptionCode::UNSPECIFIED_CRYPTOGRAPHIC_ERROR,
-        );
+        $tokenizedKey = strtok($formattedKey, "\n");
+        if ($tokenizedKey === false) {
+            throw new PasetoException('Invalid PEM format', ExceptionCode::UNSPECIFIED_CRYPTOGRAPHIC_ERROR);
+        }
 
         $key = Base64::decode($tokenizedKey);
         $prefix = Hex::decode(self::PEM_ENCODE_PREFIX);

--- a/src/Keys/Version4/AsymmetricPublicKey.php
+++ b/src/Keys/Version4/AsymmetricPublicKey.php
@@ -88,6 +88,7 @@ class AsymmetricPublicKey extends BasePublicKey
     {
         $formattedKey = str_replace('-----BEGIN PUBLIC KEY-----', '', $pem);
         $formattedKey = str_replace('-----END PUBLIC KEY-----', '', $formattedKey);
+        assert(is_string($formattedKey));
         $key = Base64::decode(strtok($formattedKey, "\n"));
         $prefix = Hex::decode(self::PEM_ENCODE_PREFIX);
 

--- a/src/Keys/Version4/AsymmetricPublicKey.php
+++ b/src/Keys/Version4/AsymmetricPublicKey.php
@@ -88,10 +88,13 @@ class AsymmetricPublicKey extends BasePublicKey
     {
         $formattedKey = str_replace('-----BEGIN PUBLIC KEY-----', '', $pem);
         $formattedKey = str_replace('-----END PUBLIC KEY-----', '', $formattedKey);
-        if (PHP_VERSION_ID >= 80400) {
-            if (!is_string($formattedKey)) {
-                throw new PasetoException('Invalid PEM format', ExceptionCode::UNSPECIFIED_CRYPTOGRAPHIC_ERROR);
-            }
+
+        /**
+         * @psalm-suppress DocblockTypeContradiction
+         * PHP 8.4 updated the docblock return for str_replace, which makes this check required
+         */
+        if (!is_string($formattedKey)) {
+            throw new PasetoException('Invalid PEM format', ExceptionCode::UNSPECIFIED_CRYPTOGRAPHIC_ERROR);
         }
 
         $tokenizedKey = strtok($formattedKey, "\n");

--- a/src/Keys/Version4/AsymmetricPublicKey.php
+++ b/src/Keys/Version4/AsymmetricPublicKey.php
@@ -63,7 +63,10 @@ class AsymmetricPublicKey extends BasePublicKey
             "-----END PUBLIC KEY-----";
     }
 
-    public static function fromEncodedString(string $encoded, ProtocolInterface $version = null): self
+    public static function fromEncodedString(
+        string $encoded,
+        ?ProtocolInterface $version = null,
+    ): self
     {
         $decoded = Base64UrlSafe::decode($encoded);
         return new self($decoded);
@@ -81,7 +84,7 @@ class AsymmetricPublicKey extends BasePublicKey
      *
      * @throws Exception
      */
-    public static function importPem(string $pem, ProtocolInterface $protocol = null): self
+    public static function importPem(string $pem, ?ProtocolInterface $protocol = null): self
     {
         $formattedKey = str_replace('-----BEGIN PUBLIC KEY-----', '', $pem);
         $formattedKey = str_replace('-----END PUBLIC KEY-----', '', $formattedKey);

--- a/src/Keys/Version4/AsymmetricPublicKey.php
+++ b/src/Keys/Version4/AsymmetricPublicKey.php
@@ -88,8 +88,16 @@ class AsymmetricPublicKey extends BasePublicKey
     {
         $formattedKey = str_replace('-----BEGIN PUBLIC KEY-----', '', $pem);
         $formattedKey = str_replace('-----END PUBLIC KEY-----', '', $formattedKey);
-        assert(is_string($formattedKey));
-        $key = Base64::decode(strtok($formattedKey, "\n"));
+        if (!is_string($formattedKey)) {
+            throw new PasetoException('Invalid PEM format', ExceptionCode::UNSPECIFIED_CRYPTOGRAPHIC_ERROR);
+        }
+
+        $tokenizedKey = strtok($formattedKey, "\n") ?: throw new PasetoException(
+            'Invalid PEM format',
+            ExceptionCode::UNSPECIFIED_CRYPTOGRAPHIC_ERROR,
+        );
+
+        $key = Base64::decode($tokenizedKey);
         $prefix = Hex::decode(self::PEM_ENCODE_PREFIX);
 
         return new self(substr($key, strlen($prefix)));

--- a/src/Keys/Version4/AsymmetricSecretKey.php
+++ b/src/Keys/Version4/AsymmetricSecretKey.php
@@ -101,14 +101,16 @@ class AsymmetricSecretKey extends BaseSecretKey
     {
         $formattedKey = str_replace('-----BEGIN EC PRIVATE KEY-----', '', $pem);
         $formattedKey = str_replace('-----END EC PRIVATE KEY-----', '', $formattedKey);
-        if (!is_string($formattedKey)) {
-            throw new PasetoException('Invalid PEM format', ExceptionCode::UNSPECIFIED_CRYPTOGRAPHIC_ERROR);
+        if (PHP_VERSION_ID >= 80400) {
+            if (!is_string($formattedKey)) {
+                throw new PasetoException('Invalid PEM format', ExceptionCode::UNSPECIFIED_CRYPTOGRAPHIC_ERROR);
+            }
         }
 
-        $tokenizedKey = strtok($formattedKey, "\n") ?: throw new PasetoException(
-            'Invalid PEM format',
-            ExceptionCode::UNSPECIFIED_CRYPTOGRAPHIC_ERROR,
-        );
+        $tokenizedKey = strtok($formattedKey, "\n");
+        if ($tokenizedKey === false) {
+            throw new PasetoException('Invalid PEM format', ExceptionCode::UNSPECIFIED_CRYPTOGRAPHIC_ERROR);
+        }
 
         $key = Base64::decode($tokenizedKey);
         $prefix = Hex::decode(self::PEM_ENCODE_PREFIX);

--- a/src/Keys/Version4/AsymmetricSecretKey.php
+++ b/src/Keys/Version4/AsymmetricSecretKey.php
@@ -51,7 +51,7 @@ class AsymmetricSecretKey extends BaseSecretKey
         parent::__construct($keyData, new Version4());
     }
 
-    public static function generate(ProtocolInterface $protocol = null): self
+    public static function generate(?ProtocolInterface $protocol = null): self
     {
         return new self(
             sodium_crypto_sign_secretkey(
@@ -75,7 +75,10 @@ class AsymmetricSecretKey extends BaseSecretKey
             "-----END EC PRIVATE KEY-----";
     }
 
-    public static function fromEncodedString(string $encoded, ProtocolInterface $version = null): self
+    public static function fromEncodedString(
+        string $encoded,
+        ?ProtocolInterface $version = null,
+    ): self
     {
         $decoded = Base64UrlSafe::decodeNoPadding($encoded);
         return new self($decoded);
@@ -94,7 +97,7 @@ class AsymmetricSecretKey extends BaseSecretKey
      *
      * @throws Exception
      */
-    public static function importPem(string $pem, ProtocolInterface $protocol = null): self
+    public static function importPem(string $pem, ?ProtocolInterface $protocol = null): self
     {
         $formattedKey = str_replace('-----BEGIN EC PRIVATE KEY-----', '', $pem);
         $formattedKey = str_replace('-----END EC PRIVATE KEY-----', '', $formattedKey);

--- a/src/Keys/Version4/AsymmetricSecretKey.php
+++ b/src/Keys/Version4/AsymmetricSecretKey.php
@@ -101,6 +101,7 @@ class AsymmetricSecretKey extends BaseSecretKey
     {
         $formattedKey = str_replace('-----BEGIN EC PRIVATE KEY-----', '', $pem);
         $formattedKey = str_replace('-----END EC PRIVATE KEY-----', '', $formattedKey);
+        assert(is_string($formattedKey));
         $key = Base64::decode(strtok($formattedKey, "\n"));
         $prefix = Hex::decode(self::PEM_ENCODE_PREFIX);
 

--- a/src/Keys/Version4/AsymmetricSecretKey.php
+++ b/src/Keys/Version4/AsymmetricSecretKey.php
@@ -101,8 +101,16 @@ class AsymmetricSecretKey extends BaseSecretKey
     {
         $formattedKey = str_replace('-----BEGIN EC PRIVATE KEY-----', '', $pem);
         $formattedKey = str_replace('-----END EC PRIVATE KEY-----', '', $formattedKey);
-        assert(is_string($formattedKey));
-        $key = Base64::decode(strtok($formattedKey, "\n"));
+        if (!is_string($formattedKey)) {
+            throw new PasetoException('Invalid PEM format', ExceptionCode::UNSPECIFIED_CRYPTOGRAPHIC_ERROR);
+        }
+
+        $tokenizedKey = strtok($formattedKey, "\n") ?: throw new PasetoException(
+            'Invalid PEM format',
+            ExceptionCode::UNSPECIFIED_CRYPTOGRAPHIC_ERROR,
+        );
+
+        $key = Base64::decode($tokenizedKey);
         $prefix = Hex::decode(self::PEM_ENCODE_PREFIX);
 
         return new self(substr($key, strlen($prefix)));

--- a/src/Keys/Version4/AsymmetricSecretKey.php
+++ b/src/Keys/Version4/AsymmetricSecretKey.php
@@ -101,10 +101,13 @@ class AsymmetricSecretKey extends BaseSecretKey
     {
         $formattedKey = str_replace('-----BEGIN EC PRIVATE KEY-----', '', $pem);
         $formattedKey = str_replace('-----END EC PRIVATE KEY-----', '', $formattedKey);
-        if (PHP_VERSION_ID >= 80400) {
-            if (!is_string($formattedKey)) {
-                throw new PasetoException('Invalid PEM format', ExceptionCode::UNSPECIFIED_CRYPTOGRAPHIC_ERROR);
-            }
+
+        /**
+         * @psalm-suppress DocblockTypeContradiction
+         * PHP 8.4 updated the docblock return for str_replace, which makes this check required
+         */
+        if (!is_string($formattedKey)) {
+            throw new PasetoException('Invalid PEM format', ExceptionCode::UNSPECIFIED_CRYPTOGRAPHIC_ERROR);
         }
 
         $tokenizedKey = strtok($formattedKey, "\n");

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -70,9 +70,9 @@ class Parser extends PasetoBase
      * @throws PasetoException
      */
     public function __construct(
-        ProtocolCollection $allowedVersions = null,
-        Purpose $purpose = null,
-        ReceivingKey $key = null,
+        ?ProtocolCollection $allowedVersions = null,
+        ?Purpose $purpose = null,
+        ?ReceivingKey $key = null,
         array $parserRules = []
     ) {
         $this->allowedVersions = $allowedVersions ?? ProtocolCollection::default();
@@ -138,7 +138,7 @@ class Parser extends PasetoBase
      */
     public static function getLocal(
         SymmetricKey $key,
-        ProtocolCollection $allowedVersions = null
+        ?ProtocolCollection $allowedVersions = null
     ): self {
         return new self(
             $allowedVersions ?? ProtocolCollection::default(),
@@ -159,7 +159,7 @@ class Parser extends PasetoBase
      */
     public static function getLocalWithKeyRing(
         ReceivingKeyRing   $key,
-        ProtocolCollection $allowedVersions = null
+        ?ProtocolCollection $allowedVersions = null
     ): self {
         return new self(
             $allowedVersions ?? ProtocolCollection::default(),
@@ -180,7 +180,7 @@ class Parser extends PasetoBase
      */
     public static function getPublic(
         AsymmetricPublicKey $key,
-        ProtocolCollection $allowedVersions = null
+        ?ProtocolCollection $allowedVersions = null
     ): self {
         return new self(
             $allowedVersions ?? ProtocolCollection::default(),
@@ -201,7 +201,7 @@ class Parser extends PasetoBase
      */
     public static function getPublicWithKeyRing(
         ReceivingKeyRing   $key,
-        ProtocolCollection $allowedVersions = null
+        ?ProtocolCollection $allowedVersions = null
     ): self {
         return new self(
             $allowedVersions ?? ProtocolCollection::default(),

--- a/src/Protocol/Version3.php
+++ b/src/Protocol/Version3.php
@@ -179,7 +179,7 @@ class Version3 implements ProtocolInterface
     public static function decrypt(
         string $data,
         SymmetricKey $key,
-        string $footer = null,
+        ?string $footer = null,
         string $implicit = ''
     ): string {
         /*
@@ -292,7 +292,7 @@ class Version3 implements ProtocolInterface
     public static function verify(
         string $signMsg,
         AsymmetricPublicKey $key,
-        string $footer = null,
+        ?string $footer = null,
         string $implicit = ''
     ): string {
         /*

--- a/src/Protocol/Version4.php
+++ b/src/Protocol/Version4.php
@@ -173,7 +173,7 @@ class Version4 implements ProtocolInterface
     public static function decrypt(
         string $data,
         SymmetricKey $key,
-        string $footer = null,
+        ?string $footer = null,
         string $implicit = ''
     ): string {
         /*
@@ -274,7 +274,7 @@ class Version4 implements ProtocolInterface
     public static function verify(
         string $signMsg,
         AsymmetricPublicKey $key,
-        string $footer = null,
+        ?string $footer = null,
         string $implicit = ''
     ): string {
         /*

--- a/src/ProtocolInterface.php
+++ b/src/ProtocolInterface.php
@@ -73,7 +73,7 @@ interface ProtocolInterface
     public static function decrypt(
         string $data,
         SymmetricKey $key,
-        string $footer = null,
+        ?string $footer = null,
         string $implicit = ''
     ): string;
 
@@ -105,7 +105,7 @@ interface ProtocolInterface
     public static function verify(
         string $signMsg,
         AsymmetricPublicKey $key,
-        string $footer = null,
+        ?string $footer = null,
         string $implicit = ''
     ): string;
 }

--- a/src/Rules/NotExpired.php
+++ b/src/Rules/NotExpired.php
@@ -22,15 +22,17 @@ class NotExpired implements ValidationRuleInterface
 
     /**
      * NotExpired constructor.
+     * 
      * @param DateTimeInterface|null $now Allows "now" to be overwritten for unit testing
      */
-    public function __construct(DateTimeInterface $now = null)
+    public function __construct(?DateTimeInterface $now = null)
     {
         if (!$now) {
             $now = new DateTime();
         }
         $this->now = $now;
     }
+
     /**
      * @return string
      */

--- a/src/Rules/ValidAt.php
+++ b/src/Rules/ValidAt.php
@@ -22,9 +22,10 @@ class ValidAt implements ValidationRuleInterface
 
     /**
      * ValidAt constructor.
+     * 
      * @param DateTimeInterface|null $now
      */
-    public function __construct(DateTimeInterface $now = null)
+    public function __construct(?DateTimeInterface $now = null)
     {
         if (!$now) {
             $now = new DateTime();

--- a/src/Util.php
+++ b/src/Util.php
@@ -46,9 +46,15 @@ abstract class Util
 
         // Remove whitespace:
         $stripped = preg_replace('/\s+/', '', $stripped);
+        if ($stripped === null) {
+            throw new EncodingException('Invalid JSON string provided', ExceptionCode::INVALID_JSON);
+        }
 
         // Strip everything out of quotes:
         $stripped = preg_replace('#"[^"]+"([:,}\]])#', '$1', $stripped);
+        if ($stripped === null) {
+            throw new EncodingException('Invalid JSON string provided', ExceptionCode::INVALID_JSON);
+        }
 
         // Remove everything that isn't a map or list definition
         $stripped = preg_replace('#[^\[\]{}]#', '', $stripped);
@@ -80,7 +86,12 @@ abstract class Util
      */
     public static function countJsonKeys(string $json): int
     {
-        return preg_match_all('#[^\\\]":#', $json);
+        $keyCount = preg_match_all('#[^\\\]":#', $json);
+        if ($keyCount === false) {
+            throw new EncodingException('Invalid JSON string provided', ExceptionCode::INVALID_JSON);
+        }
+
+        return $keyCount;
     }
 
     /**

--- a/tests/KeyTest.php
+++ b/tests/KeyTest.php
@@ -5,16 +5,18 @@ namespace ParagonIE\Paseto\Tests;
 use ParagonIE\ConstantTime\Binary;
 use ParagonIE\Paseto\Builder;
 use ParagonIE\Paseto\Exception\{PasetoException, SecurityException,};
-use ParagonIE\Paseto\Keys\{Base\AsymmetricPublicKey, Base\AsymmetricSecretKey};
 use ParagonIE\Paseto\Keys\Version4\SymmetricKey;
+use ParagonIE\Paseto\Keys\{Base\AsymmetricPublicKey, Base\AsymmetricSecretKey};
 use ParagonIE\Paseto\Protocol\{Version3, Version4};
 use ParagonIE\Paseto\Purpose;
 use ParagonIE\Paseto\Util;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class KeyTest extends TestCase
 {
-    public function pemProvider(): array
+    /** @return array<int, array<int, string>> */
+    public static function pemProvider(): array
     {
         return [
             [
@@ -54,9 +56,7 @@ class KeyTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider pemProvider
-     */
+    #[DataProvider('pemProvider')]
     public function testExportImportPem(AsymmetricSecretKey $sk, string $skPem, string $pkPem): void
     {
         $this->assertSame($skPem, $sk->encodePem());

--- a/tests/LucidityTest.php
+++ b/tests/LucidityTest.php
@@ -7,6 +7,7 @@ use ParagonIE\Paseto\Exception\PasetoException;
 use ParagonIE\Paseto\KeyInterface;
 use ParagonIE\Paseto\Keys\Base\SymmetricKey;
 use ParagonIE\Paseto\Protocol\{Version3, Version4};
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use TypeError;
 
@@ -16,7 +17,7 @@ class LucidityTest extends TestCase
      * @return array[]
      * @throws Exception
      */
-    public function luciditySymmetric(): array
+    public static function luciditySymmetric(): array
     {
         $v4_lk = Version4::generateSymmetricKey();
         $v4_sk = Version4::generateAsymmetricSecretKey();
@@ -45,10 +46,10 @@ class LucidityTest extends TestCase
      * @param KeyInterface $validKey
      * @param KeyInterface $invalidKey
      *
-     * @dataProvider luciditySymmetric
      * @throws Exception
      * @throws PasetoException
      */
+    #[DataProvider('luciditySymmetric')]
     public function testLocalLucidity(
         $protocol,
         KeyInterface $validKey,

--- a/tests/MultiKeyTest.php
+++ b/tests/MultiKeyTest.php
@@ -86,6 +86,10 @@ class MultiKeyTest extends TestCase
          * @var ReceivingKeyRing $keyring
          */
         list($sk, $keyring) = $this->getReceivingKeyring($v);
+        // Let's make sure we're not in a weird state
+        if ($v::header() === Version4::header()) {
+            $this->assertSame(SODIUM_CRYPTO_SIGN_SECRETKEYBYTES, $sk->raw(), 'Incorrect secret key size');
+        }
 
         // These need to pass the type checks
         $localKey = $keyring->fetchKey('gandalf0');

--- a/tests/MultiKeyTest.php
+++ b/tests/MultiKeyTest.php
@@ -17,6 +17,7 @@ use ParagonIE\Paseto\{Builder,
     SendingKeyRing};
 use ParagonIE\Paseto\Keys\{Base\AsymmetricSecretKey, Base\SymmetricKey};
 use ParagonIE\Paseto\Protocol\{Version3, Version4};
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use TypeError;
 
@@ -233,7 +234,7 @@ class MultiKeyTest extends TestCase
      * @return array[]
      * @throws Exception
      */
-    public function typeCheckData(): array
+    public static function typeCheckData(): array
     {
         $v3_lk = Version3::generateSymmetricKey();
         $v3_sk = Version3::generateAsymmetricSecretKey();
@@ -472,8 +473,6 @@ class MultiKeyTest extends TestCase
     }
 
     /**
-     * @dataProvider typeCheckData
-     *
      * @param SendingKeyRing|ReceivingKeyRing $keyring
      * @param SendingKey|ReceivingKey $key
      * @param bool $expectFail
@@ -481,6 +480,7 @@ class MultiKeyTest extends TestCase
      * @psalm-suppress PossiblyInvalidArgument
      * @throws PasetoException
      */
+    #[DataProvider('typeCheckData')]
     public function testTypeChecks(
         SendingKeyRing|ReceivingKeyRing$keyring,
         SendingKey|ReceivingKey $key,

--- a/tests/MultiKeyTest.php
+++ b/tests/MultiKeyTest.php
@@ -88,7 +88,7 @@ class MultiKeyTest extends TestCase
         list($sk, $keyring) = $this->getReceivingKeyring($v);
         // Let's make sure we're not in a weird state
         if ($v::header() === Version4::header()) {
-            $this->assertSame(SODIUM_CRYPTO_SIGN_SECRETKEYBYTES, $sk->raw(), 'Incorrect secret key size');
+            $this->assertSame(SODIUM_CRYPTO_SIGN_SECRETKEYBYTES, strlen($sk->raw()), 'Incorrect secret key size');
         }
 
         // These need to pass the type checks

--- a/tests/PurposeTest.php
+++ b/tests/PurposeTest.php
@@ -31,76 +31,74 @@ use Exception;
 
 class PurposeTest extends TestCase
 {
-    protected bool $setUpAtRuntime = false;
-    protected AsymmetricSecretKey $bsk;
-    protected AsymmetricPublicKey $bpk;
-    protected SymmetricKey $bk;
-    protected AsymmetricSecretKey $lsk;
-    protected AsymmetricPublicKey $lpk;
-    protected SymmetricKey $lk;
-    protected AsymmetricSecretKey $sk3;
-    protected AsymmetricPublicKey $pk3;
-    protected SymmetricKey $k3;
-    protected AsymmetricSecretKey $sk4;
-    protected AsymmetricPublicKey $pk4;
-    protected SymmetricKey $k4;
+    protected static AsymmetricSecretKey $bsk;
+    protected static AsymmetricPublicKey $bpk;
+    protected static SymmetricKey $bk;
+    protected static AsymmetricSecretKey $lsk;
+    protected static AsymmetricPublicKey $lpk;
+    protected static SymmetricKey $lk;
+    protected static AsymmetricSecretKey $sk3;
+    protected static AsymmetricPublicKey $pk3;
+    protected static SymmetricKey $k3;
+    protected static AsymmetricSecretKey $sk4;
+    protected static AsymmetricPublicKey $pk4;
+    protected static SymmetricKey $k4;
 
     /**
-     * @return void
-     *
      * @throws Exception
      */
-    public function setUp(): void
+    protected static function setupKeys(): void
     {
-        $this->bsk = AsymmetricSecretKey::generate();
-        $this->bpk = $this->bsk->getPublicKey();
-        $this->bk = SymmetricKey::generate();
+        self::$bsk = AsymmetricSecretKey::generate();
+        self::$bpk = self::$bsk->getPublicKey();
+        self::$bk = SymmetricKey::generate();
 
-        $this->lsk = LegacyAsymmetricSecretKey::generate();
-        $this->lpk = $this->lsk->getPublicKey();
-        $this->lk = LegacySymmetricKey::generate();
+        self::$lsk = LegacyAsymmetricSecretKey::generate();
+        self::$lpk = self::$lsk->getPublicKey();
+        self::$lk = LegacySymmetricKey::generate();
 
-        $this->sk3 = V3AsymmetricSecretKey::generate();
-        $this->pk3 = $this->sk3->getPublicKey();
-        $this->k3 = V3SymmetricKey::generate();
+        self::$sk3 = V3AsymmetricSecretKey::generate();
+        self::$pk3 = self::$sk3->getPublicKey();
+        self::$k3 = V3SymmetricKey::generate();
 
-        $this->sk4 = V4AsymmetricSecretKey::generate();
-        $this->pk4 = $this->sk4->getPublicKey();
-        $this->k4 = V4SymmetricKey::generate();
+        self::$sk4 = V4AsymmetricSecretKey::generate();
+        self::$pk4 = self::$sk4->getPublicKey();
+        self::$k4 = V4SymmetricKey::generate();
     }
 
+    /**
+     * @return array<array<AsymmetricPublicKey|SymmetricKey|string>>
+     */
     public static function receivingKeyProvider(): array
     {
-        if (!$this->setUpAtRuntime) {
-            $this->setUp();
-        }
-        return [
-            [$this->bk, 'local'],
-            [$this->lpk, 'public'],
-            [$this->pk3, 'public'],
-            [$this->pk4, 'public'],
-            [$this->lk, 'local']
-        ];
-    }
+        self::setupKeys();
 
-    public static function sendingKeyProvider(): array
-    {
-        if (!$this->setUpAtRuntime) {
-            $this->setUp();
-        }
         return [
-            [$this->bk, 'local'],
-            [$this->lsk, 'public'],
-            [$this->sk3, 'public'],
-            [$this->sk4, 'public'],
-            [$this->lk, 'local']
+            [self::$bk, 'local'],
+            [self::$lpk, 'public'],
+            [self::$pk3, 'public'],
+            [self::$pk4, 'public'],
+            [self::$lk, 'local']
         ];
     }
 
     /**
-     * @param ReceivingKey $key
-     * @param string $expected
-     * @return void
+     * @return array<array<AsymmetricSecretKey|SymmetricKey|string>>
+     */
+    public static function sendingKeyProvider(): array
+    {
+        self::setupKeys();
+
+        return [
+            [self::$bk, 'local'],
+            [self::$lsk, 'public'],
+            [self::$sk3, 'public'],
+            [self::$sk4, 'public'],
+            [self::$lk, 'local']
+        ];
+    }
+
+    /**
      * @throws InvalidPurposeException
      */
     #[DataProvider('receivingKeyProvider')]
@@ -111,9 +109,6 @@ class PurposeTest extends TestCase
     }
 
     /**
-     * @param SendingKey $key
-     * @param string $expected
-     * @return void
      * @throws InvalidPurposeException
      */
     #[DataProvider('sendingKeyProvider')]

--- a/tests/PurposeTest.php
+++ b/tests/PurposeTest.php
@@ -26,6 +26,7 @@ use ParagonIE\Paseto\{
     SendingKey
 };
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Exception;
 
 class PurposeTest extends TestCase

--- a/tests/PurposeTest.php
+++ b/tests/PurposeTest.php
@@ -62,13 +62,13 @@ class PurposeTest extends TestCase
         $this->sk3 = V3AsymmetricSecretKey::generate();
         $this->pk3 = $this->sk3->getPublicKey();
         $this->k3 = V3SymmetricKey::generate();
-        
+
         $this->sk4 = V4AsymmetricSecretKey::generate();
         $this->pk4 = $this->sk4->getPublicKey();
         $this->k4 = V4SymmetricKey::generate();
     }
 
-    public function receivingKeyProvider(): array
+    public static function receivingKeyProvider(): array
     {
         if (!$this->setUpAtRuntime) {
             $this->setUp();
@@ -82,7 +82,7 @@ class PurposeTest extends TestCase
         ];
     }
 
-    public function sendingKeyProvider(): array
+    public static function sendingKeyProvider(): array
     {
         if (!$this->setUpAtRuntime) {
             $this->setUp();
@@ -97,13 +97,12 @@ class PurposeTest extends TestCase
     }
 
     /**
-     * @dataProvider receivingKeyProvider
-     *
      * @param ReceivingKey $key
      * @param string $expected
      * @return void
      * @throws InvalidPurposeException
      */
+    #[DataProvider('receivingKeyProvider')]
     public function testReceivingMapping(ReceivingKey $key, string $expected): void
     {
         $purpose = Purpose::fromReceivingKey($key);
@@ -111,13 +110,12 @@ class PurposeTest extends TestCase
     }
 
     /**
-     * @dataProvider sendingKeyProvider
-     *
      * @param SendingKey $key
      * @param string $expected
      * @return void
      * @throws InvalidPurposeException
      */
+    #[DataProvider('sendingKeyProvider')]
     public function testSendingMapping(SendingKey $key, string $expected): void
     {
         $purpose = Purpose::fromSendingKey($key);


### PR DESCRIPTION
This PR includes some updates for deprecations, PHPUnit and resolved Psalm errors, as some typing and hinting has changed in PHP 8.4.

Psalm 8.4 syntax support is only supported on `dev-master`.  I don't see any issues here as this is only a dev dependency.

Unfortunately, at the moment, there is a newly introduced bug in PHP that's resulting in specific `DataProvider` tests failing.  That should be resolved in the next minor release.  See https://github.com/php/php-src/issues/16870 for more details.  After this is resolved, tests should be passing.