### PR TITLE
Use early static binding/typing

### DIFF
--- a/src/Keys/Base/AsymmetricPublicKey.php
+++ b/src/Keys/Base/AsymmetricPublicKey.php
@@ -59,12 +59,9 @@ abstract class AsymmetricPublicKey implements ReceivingKey
     /**
      * This used to initialize a v1 public key, but it was deprecated then removed.
      *
-     * @param string $keyMaterial
-     * @return self
-     *
      * @throws InvalidVersionException
      */
-    public static function v1(string $keyMaterial): self
+    public static function v1(string $keyMaterial): static
     {
         throw new InvalidVersionException("Version 1 was removed", ExceptionCode::OBSOLETE_PROTOCOL);
     }
@@ -72,21 +69,15 @@ abstract class AsymmetricPublicKey implements ReceivingKey
     /**
      * This used to initialize a v2 public key, but it was deprecated then removed.
      *
-     * @param string $keyMaterial
-     * @return self
-     *
      * @throws InvalidVersionException
      */
-    public static function v2(string $keyMaterial): self
+    public static function v2(string $keyMaterial): static
     {
         throw new InvalidVersionException("Version 2 was removed", ExceptionCode::OBSOLETE_PROTOCOL);
     }
 
     /**
      * Initialize a v3 public key.
-     *
-     * @param string $keyMaterial
-     * @return V3AsymmetricPublicKey
      *
      * @throws Exception
      */
@@ -98,9 +89,6 @@ abstract class AsymmetricPublicKey implements ReceivingKey
     /**
      * Initialize a v4 public key.
      *
-     * @param string $keyMaterial
-     * @return V4AsymmetricPublicKey
-     *
      * @throws Exception
      */
     public static function v4(string $keyMaterial): V4AsymmetricPublicKey
@@ -110,10 +98,6 @@ abstract class AsymmetricPublicKey implements ReceivingKey
 
     /**
      * Initialize a public key.
-     *
-     * @param string $keyMaterial
-     * @param ?ProtocolInterface $protocol
-     * @return self
      *
      * @throws Exception
      */
@@ -134,8 +118,6 @@ abstract class AsymmetricPublicKey implements ReceivingKey
     /**
      * Returns the base64url-encoded public key.
      *
-     * @return string
-     *
      * @throws TypeError
      * @throws PasetoException
      */
@@ -143,17 +125,11 @@ abstract class AsymmetricPublicKey implements ReceivingKey
 
     /**
      * Return a PEM-encoded public key
-     *
-     * @return string
      */
     abstract public function encodePem(): string;
 
     /**
      * Initialize a public key from a base64url-encoded string.
-     *
-     * @param string $encoded
-     * @param ProtocolInterface|null $version
-     * @return self
      *
      * @throws Exception
      * @throws TypeError
@@ -175,10 +151,6 @@ abstract class AsymmetricPublicKey implements ReceivingKey
 
 
     /**
-     * @param string $pem
-     * @param ProtocolInterface|null $protocol
-     * @return self
-     *
      * @throws Exception
      */
     public static function importPem(string $pem, ?ProtocolInterface $protocol = null): self
@@ -195,25 +167,18 @@ abstract class AsymmetricPublicKey implements ReceivingKey
     }
 
     /**
-     * @return string
      * @throws ParserException
      */
     abstract public function toHexString(): string;
 
     /**
      * Get the version of PASETO that this key is intended for.
-     *
-     * @return ProtocolInterface
      */
     public function getProtocol(): ProtocolInterface
     {
         return $this->protocol;
     }
 
-    /**
-     * @param ProtocolInterface $protocol
-     * @return bool
-     */
     public function isForVersion(ProtocolInterface $protocol): bool
     {
         return $this->protocol instanceof $protocol;
@@ -221,8 +186,6 @@ abstract class AsymmetricPublicKey implements ReceivingKey
 
     /**
      * Get the raw key contents.
-     *
-     * @return string
      */
     public function raw(): string
     {
@@ -230,7 +193,7 @@ abstract class AsymmetricPublicKey implements ReceivingKey
     }
 
     /**
-     * @return array
+     * @return array<>
      */
     public function __debugInfo()
     {

--- a/src/Keys/Base/AsymmetricSecretKey.php
+++ b/src/Keys/Base/AsymmetricSecretKey.php
@@ -100,12 +100,9 @@ abstract class AsymmetricSecretKey implements SendingKey
     /**
      * This used to initialize a v1 secret key, but it was deprecated then removed.
      *
-     * @param string $keyMaterial
-     * @return self
-     *
      * @throws InvalidVersionException
      */
-    public static function v1(string $keyMaterial): self
+    public static function v1(string $keyMaterial): static
     {
         throw new InvalidVersionException("Version 1 was removed", ExceptionCode::OBSOLETE_PROTOCOL);
     }
@@ -113,20 +110,14 @@ abstract class AsymmetricSecretKey implements SendingKey
     /**
      * This used to initialize a v2 secret key, but it was deprecated then removed.
      *
-     * @param string $keyMaterial
-     * @return self
-     *
      * @throws InvalidVersionException
      */
-    public static function v2(string $keyMaterial): self
+    public static function v2(string $keyMaterial): static
     {throw new InvalidVersionException("Version 2 was removed", ExceptionCode::OBSOLETE_PROTOCOL);
     }
 
     /**
      * Initialize a v3 secret key.
-     *
-     * @param string $keyMaterial
-     * @return V3AsymmetricSecretKey
      *
      * @throws Exception
      * @throws TypeError
@@ -139,9 +130,6 @@ abstract class AsymmetricSecretKey implements SendingKey
     /**
      * Initialize a v4 secret key.
      *
-     * @param string $keyMaterial
-     * @return V4AsymmetricSecretKey
-     *
      * @throws Exception
      * @throws TypeError
      */
@@ -152,9 +140,6 @@ abstract class AsymmetricSecretKey implements SendingKey
 
     /**
      * Generate a secret key.
-     *
-     * @param ProtocolInterface|null $protocol
-     * @return self
      *
      * @throws Exception
      * @throws TypeError
@@ -172,10 +157,6 @@ abstract class AsymmetricSecretKey implements SendingKey
     /**
      * Initialize a public key.
      *
-     * @param string $keyMaterial
-     * @param ?ProtocolInterface $protocol
-     * @return self
-     *
      * @throws Exception
      */
     public static function newVersionKey(string $keyMaterial, ?ProtocolInterface $protocol = null): self
@@ -192,8 +173,6 @@ abstract class AsymmetricSecretKey implements SendingKey
     /**
      * Return a base64url-encoded representation of this secret key.
      *
-     * @return string
-     *
      * @throws TypeError
      */
     abstract public function encode(): string;
@@ -201,17 +180,12 @@ abstract class AsymmetricSecretKey implements SendingKey
     /**
      * Return a PEM-encoded secret key
      *
-     * @return string
      * @throws PasetoException
      */
     abstract public function encodePem(): string;
 
     /**
      * Initialize a secret key from a base64url-encoded string.
-     *
-     * @param string $encoded
-     * @param ProtocolInterface|null $version
-     * @return self
      *
      * @throws Exception
      * @throws TypeError
@@ -226,11 +200,7 @@ abstract class AsymmetricSecretKey implements SendingKey
     }
 
     /**
-     * @param string $pem
-     * @param ProtocolInterface|null $protocol
-     * @return self
-     *
-     * @throws Exception
+     * @throws InvalidVersionException
      */
     public static function importPem(string $pem, ?ProtocolInterface $protocol = null): self
     {
@@ -247,18 +217,12 @@ abstract class AsymmetricSecretKey implements SendingKey
 
     /**
      * Get the version of PASETO that this key is intended for.
-     *
-     * @return ProtocolInterface
      */
     public function getProtocol(): ProtocolInterface
     {
         return $this->protocol;
     }
 
-    /**
-     * @param ProtocolInterface $protocol
-     * @return bool
-     */
     public function isForVersion(ProtocolInterface $protocol): bool
     {
         return $this->protocol instanceof $protocol;
@@ -267,8 +231,6 @@ abstract class AsymmetricSecretKey implements SendingKey
     /**
      * Get the public key that corresponds to this secret key.
      *
-     * @return AsymmetricPublicKey
-     *
      * @throws Exception
      * @throws TypeError
      */
@@ -276,8 +238,6 @@ abstract class AsymmetricSecretKey implements SendingKey
 
     /**
      * Get the raw key contents.
-     *
-     * @return string
      */
     public function raw(): string
     {
@@ -285,7 +245,7 @@ abstract class AsymmetricSecretKey implements SendingKey
     }
 
     /**
-     * @return array
+     * @return array<>
      */
     public function __debugInfo()
     {

--- a/src/Keys/Base/SymmetricKey.php
+++ b/src/Keys/Base/SymmetricKey.php
@@ -38,9 +38,6 @@ class SymmetricKey implements ReceivingKey, SendingKey
     /**
      * SymmetricKey constructor.
      *
-     * @param string $keyMaterial
-     * @param ProtocolInterface|null $protocol
-     *
      * @throws PasetoException
      */
     public function __construct(
@@ -76,19 +73,16 @@ class SymmetricKey implements ReceivingKey, SendingKey
     }
 
     /**
-     * @param ProtocolInterface|null $protocol
-     * @return SymmetricKey
-     *
-     * @throws Exception
+     * @throws PasetoException
      */
-    public static function generate(?ProtocolInterface $protocol = null): self
+    public static function generate(?ProtocolInterface $protocol = null): static
     {
         $protocol = $protocol ?? new Version4;
         $length = $protocol::getSymmetricKeyByteLength();
         if ($length < 32) {
             throw new PasetoException("Invalid key length");
         }
-        return new self(
+        return new static(
             random_bytes($length),
             $protocol
         );
@@ -97,12 +91,9 @@ class SymmetricKey implements ReceivingKey, SendingKey
     /**
      * This used to initialize a v1 symmetric key, but it was deprecated then removed.
      *
-     * @param string $keyMaterial
-     * @return self
-     *
      * @throws InvalidVersionException
      */
-    public static function v1(string $keyMaterial): self
+    public static function v1(string $keyMaterial): static
     {
         throw new InvalidVersionException("Version 1 was removed", ExceptionCode::OBSOLETE_PROTOCOL);
     }
@@ -110,12 +101,9 @@ class SymmetricKey implements ReceivingKey, SendingKey
     /**
      * This used to initialize a v2 symmetric key, but it was deprecated then removed.
      *
-     * @param string $keyMaterial
-     * @return self
-     *
      * @throws InvalidVersionException
      */
-    public static function v2(string $keyMaterial): self
+    public static function v2(string $keyMaterial): static
     {
         throw new InvalidVersionException("Version 2 was removed", ExceptionCode::OBSOLETE_PROTOCOL);
     }
@@ -123,37 +111,27 @@ class SymmetricKey implements ReceivingKey, SendingKey
     /**
      * Initialize a v3 symmetric key.
      *
-     * @param string $keyMaterial
-     *
-     * @return self
-     *
      * @throws Exception
      * @throws TypeError
      */
-    public static function v3(string $keyMaterial): self
+    public static function v3(string $keyMaterial): static
     {
-        return new self($keyMaterial, new Version3());
+        return new static($keyMaterial, new Version3());
     }
 
     /**
      * Initialize a v4 symmetric key.
      *
-     * @param string $keyMaterial
-     *
-     * @return self
-     *
      * @throws Exception
      * @throws TypeError
      */
-    public static function v4(string $keyMaterial): self
+    public static function v4(string $keyMaterial): static
     {
-        return new self($keyMaterial, new Version4());
+        return new static($keyMaterial, new Version4());
     }
 
     /**
      * Return a base64url-encoded representation of this symmetric key.
-     *
-     * @return string
      *
      * @throws TypeError
      */
@@ -165,20 +143,16 @@ class SymmetricKey implements ReceivingKey, SendingKey
     /**
      * Initialize a symmetric key from a base64url-encoded string.
      *
-     * @param string $encoded
-     * @param ProtocolInterface|null $version
-     * @return self
-     *
      * @throws TypeError
      * @throws PasetoException
      */
     public static function fromEncodedString(
         string $encoded,
         ?ProtocolInterface $version = null,
-    ): self
+    ): static
     {
         $decoded = Base64UrlSafe::decodeNoPadding($encoded);
-        return new self($decoded, $version);
+        return new static($decoded, $version);
     }
 
     /**
@@ -191,10 +165,6 @@ class SymmetricKey implements ReceivingKey, SendingKey
         return $this->protocol;
     }
 
-    /**
-     * @param ProtocolInterface $protocol
-     * @return bool
-     */
     public function isForVersion(ProtocolInterface $protocol): bool
     {
         return $this->protocol instanceof $protocol;
@@ -202,8 +172,6 @@ class SymmetricKey implements ReceivingKey, SendingKey
 
     /**
      * Get the raw key contents.
-     *
-     * @return string
      */
     public function raw(): string
     {
@@ -216,7 +184,6 @@ class SymmetricKey implements ReceivingKey, SendingKey
      *
      * Used in version 3
      *
-     * @param string $salt
      * @return array<int, string>
      *
      * @throws TypeError
@@ -247,7 +214,6 @@ class SymmetricKey implements ReceivingKey, SendingKey
      *
      * Used in version 4
      *
-     * @param string $salt
      * @return array<int, string>
      *
      * @throws SodiumException

--- a/src/Keys/Version3/AsymmetricPublicKey.php
+++ b/src/Keys/Version3/AsymmetricPublicKey.php
@@ -102,10 +102,6 @@ class AsymmetricPublicKey extends BasePublicKey
     }
 
     /**
-     * @param string $pem
-     * @param ProtocolInterface|null $protocol
-     * @return self
-     *
      * @throws Exception
      */
     public static function importPem(string $pem, ?ProtocolInterface $protocol = null): self

--- a/src/Keys/Version3/AsymmetricSecretKey.php
+++ b/src/Keys/Version3/AsymmetricSecretKey.php
@@ -24,8 +24,6 @@ class AsymmetricSecretKey extends BaseSecretKey
     /**
      * AsymmetricSecretKey constructor.
      *
-     * @param string $keyData
-     *
      * @throws TypeError
      * @psalm-suppress UndefinedAttributeClass
      */

--- a/src/Keys/Version3/SymmetricKey.php
+++ b/src/Keys/Version3/SymmetricKey.php
@@ -14,9 +14,6 @@ class SymmetricKey extends BaseSymmetricKey
 {
     /**
      * SymmetricKey.php constructor.
-     *
-     * @param string $keyMaterial
-     * @param ProtocolInterface|null $protocol
      */
     public function __construct(
         string $keyMaterial

--- a/src/Keys/Version4/AsymmetricPublicKey.php
+++ b/src/Keys/Version4/AsymmetricPublicKey.php
@@ -27,8 +27,6 @@ class AsymmetricPublicKey extends BasePublicKey
     /**
      * AsymmetricPublicKey constructor.
      *
-     * @param string $keyData
-     *
      * @throws Exception
      * @throws TypeError
      */
@@ -78,10 +76,6 @@ class AsymmetricPublicKey extends BasePublicKey
     }
 
     /**
-     * @param string $pem
-     * @param ProtocolInterface|null $protocol
-     * @return self
-     *
      * @throws Exception
      */
     public static function importPem(string $pem, ?ProtocolInterface $protocol = null): self

--- a/src/Keys/Version4/AsymmetricSecretKey.php
+++ b/src/Keys/Version4/AsymmetricSecretKey.php
@@ -27,8 +27,6 @@ class AsymmetricSecretKey extends BaseSecretKey
     /**
      * AsymmetricSecretKey constructor.
      *
-     * @param string $keyData
-     *
      * @throws Exception
      * @throws TypeError
      */
@@ -92,9 +90,6 @@ class AsymmetricSecretKey extends BaseSecretKey
     }
 
     /**
-     * @param string $pem
-     * @return self
-     *
      * @throws Exception
      */
     public static function importPem(string $pem, ?ProtocolInterface $protocol = null): self

--- a/src/Keys/Version4/SymmetricKey.php
+++ b/src/Keys/Version4/SymmetricKey.php
@@ -13,8 +13,6 @@ class SymmetricKey extends BaseSymmetricKey
 {
     /**
      * SymmetricKey.php constructor.
-     *
-     * @param string $keyMaterial
      */
     public function __construct(
         string $keyMaterial


### PR DESCRIPTION
When instantiating a versioned `SymmetricKey`, or even an `Asymmetric{Public}Key`, should those classes be properly refactored, the base class should return a static instance, such that the instantiated version of the class is the one called - not the base class.